### PR TITLE
Simplification and new utils

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -22,5 +22,5 @@ jobs:
           cmake -S . -B build $EXTRA_CMAKE_FLAGS
           cmake --build build/ -j 4
 
-      - name: Run tess
+      - name: Run tests
         run: ctest -V --test-dir build/

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -1,0 +1,26 @@
+name: Unit tests
+on:
+  push:
+    branches: [develop]
+  pull_request:
+    branches: [develop]
+
+jobs:
+  build_and_test:
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, ubuntu-22.04, macos-13, macos-14]
+    runs-on: ${{ matrix.os }}
+    env:
+      EXTRA_CMAKE_FLAGS: -DCMAKE_BUILD_TYPE=Release -DEDUCE_CORE_BUILD_TESTS=ON -DEDUCE_CORE_BUILD_EXAMPLES=ON
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build libcore
+        run: |
+          cmake -S . -B build -GNinja $EXTRA_CMAKE_FLAGS
+          cmake --build build/
+
+      - name: Run tess
+        run: ctest -V --test-dir build/

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -19,8 +19,8 @@ jobs:
 
       - name: Build libcore
         run: |
-          cmake -S . -B build -GNinja $EXTRA_CMAKE_FLAGS
-          cmake --build build/
+          cmake -S . -B build $EXTRA_CMAKE_FLAGS
+          cmake --build build/ -j 0
 
       - name: Run tess
         run: ctest -V --test-dir build/

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Build libcore
         run: |
           cmake -S . -B build $EXTRA_CMAKE_FLAGS
-          cmake --build build/ -j 0
+          cmake --build build/ -j 4
 
       - name: Run tess
         run: ctest -V --test-dir build/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,19 +1,14 @@
 ### Prototype build jobs ###
 .build_script: &build_script
-  - mkdir -p build/
-  - cd build/
-  - echo $CMAKE_CMD
-  - $CMAKE_CMD
-  - ninja
+  - cmake -S . -B build/ -GNinja $EXTRA_CMAKE_FLAGS
+  - cmake --build build/
 
 .test_script: &test_script
-  - ctest -V
+  - ctest -V --test-dir build/
 
 .build:
   variables:
     EXTRA_CMAKE_FLAGS: ""
-  before_script:
-    - export CMAKE_CMD="cmake -GNinja $EXTRA_CMAKE_FLAGS .."
   script:
     - *build_script
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
-project(EduceLabCore VERSION 0.1)
+project(EduceLabCore VERSION 0.2.0)
 
 # Setup project directories
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin)

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ A single C++ library for types and utilities shared across the various EduceLab 
 
 ```shell
 # Get the source
-git clone https://gitlab.com/educelab/libcore.git
+git clone https://github.com/educelab/libcore.git
 cd libcore/
 
 # Build the library
-mkdir build
 cmake -S . -B build/ -DCMAKE_BUILD_TYPE=Release
+cmake --build build/
 ```
 
 ## Installation

--- a/include/educelab/core/types/Color.hpp
+++ b/include/educelab/core/types/Color.hpp
@@ -97,7 +97,7 @@ public:
     }
 
     /** @brief Construct from hexadecimal string */
-    explicit Color(std::string_view str)
+    explicit Color(const std::string_view str)
     {
         if (not std::regex_match(
                 str.begin(), str.end(), detail::REGEX_HEX_COLOR)) {
@@ -122,7 +122,7 @@ public:
     }
 
     /** @brief Assign a hexadecimal string value */
-    auto operator=(std::string_view str) -> Color&
+    auto operator=(const std::string_view str) -> Color&
     {
         if (not std::regex_match(
                 str.begin(), str.end(), detail::REGEX_HEX_COLOR)) {

--- a/include/educelab/core/types/Image.hpp
+++ b/include/educelab/core/types/Image.hpp
@@ -121,13 +121,13 @@ private:
 };
 
 template <typename T>
-auto Image::at(std::size_t y, std::size_t x) -> T&
+auto Image::at(const std::size_t y, const std::size_t x) -> T&
 {
     return reinterpret_cast<T&>(data_.at(unravel_(y, x)));
 }
 
 template <typename T>
-auto Image::at(std::size_t y, std::size_t x) const -> const T&
+auto Image::at(const std::size_t y, const std::size_t x) const -> const T&
 {
     return reinterpret_cast<const T&>(data_.at(unravel_(y, x)));
 }

--- a/include/educelab/core/types/Mat.hpp
+++ b/include/educelab/core/types/Mat.hpp
@@ -92,10 +92,7 @@ public:
 
 private:
     /** Compute flat index */
-    static inline auto Unravel(std::size_t y, std::size_t x)
-    {
-        return y * Cols + x;
-    }
+    static auto Unravel(std::size_t y, std::size_t x) { return y * Cols + x; }
     /** Storage array */
     std::array<T, Rows * Cols> vals_{};
 };

--- a/include/educelab/core/types/Mat.hpp
+++ b/include/educelab/core/types/Mat.hpp
@@ -39,25 +39,25 @@ public:
     }
 
     /** @brief Matrix element access with bounds checking */
-    auto at(std::size_t y, std::size_t x) -> T&
+    auto at(const std::size_t y, const std::size_t x) -> T&
     {
         return vals_.at(Unravel(y, x));
     }
 
     /** @copydoc at(std::size_t, std::size_t) */
-    auto at(std::size_t y, std::size_t x) const -> const T&
+    auto at(const std::size_t y, const std::size_t x) const -> const T&
     {
         return vals_.at(Unravel(y, x));
     }
 
     /** @brief Matrix element access without bounds checking */
-    auto operator()(std::size_t y, std::size_t x) -> T&
+    auto operator()(const std::size_t y, const std::size_t x) -> T&
     {
         return vals_[Unravel(y, x)];
     }
 
     /** @copydoc operator()(std::size_t, std::size_t) */
-    auto operator()(std::size_t y, std::size_t x) const -> const T&
+    auto operator()(const std::size_t y, const std::size_t x) const -> const T&
     {
         return vals_[Unravel(y, x)];
     }
@@ -92,7 +92,10 @@ public:
 
 private:
     /** Compute flat index */
-    static auto Unravel(std::size_t y, std::size_t x) { return y * Cols + x; }
+    static auto Unravel(const std::size_t y, const std::size_t x)
+    {
+        return y * Cols + x;
+    }
     /** Storage array */
     std::array<T, Rows * Cols> vals_{};
 };

--- a/include/educelab/core/types/Mesh.hpp
+++ b/include/educelab/core/types/Mesh.hpp
@@ -181,13 +181,16 @@ public:
     }
 
     /** @brief Get a face by index */
-    [[nodiscard]] auto face(std::size_t idx) const -> const Face&
+    [[nodiscard]] auto face(const std::size_t idx) const -> const Face&
     {
         return faces_.at(idx);
     }
 
     /** @brief Get a face by index */
-    [[nodiscard]] auto face(std::size_t idx) -> Face& { return faces_.at(idx); }
+    [[nodiscard]] auto face(const std::size_t idx) -> Face&
+    {
+        return faces_.at(idx);
+    }
 
 private:
     /** Vertices */

--- a/include/educelab/core/types/Mesh.hpp
+++ b/include/educelab/core/types/Mesh.hpp
@@ -24,7 +24,7 @@ namespace traits
 template <
     typename T,
     std::size_t Dims,
-    std::enable_if_t<std::is_arithmetic<T>::value, bool> = true>
+    std::enable_if_t<std::is_arithmetic_v<T>, bool> = true>
 struct DefaultVertexTraits {
     /** @brief Vertex normal */
     std::optional<Vec<T, Dims>> normal;
@@ -45,7 +45,7 @@ template <
     typename T,
     std::size_t Dims,
     typename VertexTraits = traits::DefaultVertexTraits<T, Dims>,
-    std::enable_if_t<std::is_arithmetic<T>::value, bool> = true>
+    std::enable_if_t<std::is_arithmetic_v<T>, bool> = true>
 class Mesh
 {
 public:

--- a/include/educelab/core/types/Signals.hpp
+++ b/include/educelab/core/types/Signals.hpp
@@ -85,9 +85,8 @@ public:
      * @brief Connect signals with parameters to functions without parameters
      */
     template <
-        class Enabled = typename std::enable_if<
-            std::is_empty<std::tuple<Types...>(Types...)>::value,
-            bool>>
+        class Enabled = typename std::
+            enable_if<std::is_empty_v<std::tuple<Types...>(Types...)>, bool>>
     void connect(const std::function<void()>& slot)
     {
         connections_.emplace_back([=](Types&&... /*unused*/) { slot(); });

--- a/include/educelab/core/types/Vec.hpp
+++ b/include/educelab/core/types/Vec.hpp
@@ -23,7 +23,7 @@ namespace educelab
 template <
     typename T,
     std::size_t Dims,
-    std::enable_if_t<std::is_arithmetic<T>::value, bool> = true>
+    std::enable_if_t<std::is_arithmetic_v<T>, bool> = true>
 class Vec
 {
     /** Underlying element storage */
@@ -192,7 +192,7 @@ public:
     /** @brief Assignment operator for std::initializer_list */
     template <
         typename T2,
-        std::enable_if_t<std::is_arithmetic<T2>::value, bool> = true>
+        std::enable_if_t<std::is_arithmetic_v<T2>, bool> = true>
     auto operator=(const std::initializer_list<T2>& b) -> Vec&
     {
         auto it = b.begin();
@@ -217,7 +217,7 @@ public:
     /** @brief Addition assignment operator for std::initializer_list */
     template <
         typename T2,
-        std::enable_if_t<std::is_arithmetic<T2>::value, bool> = true>
+        std::enable_if_t<std::is_arithmetic_v<T2>, bool> = true>
     auto operator+=(const std::initializer_list<T2>& b) -> Vec&
     {
         auto it = b.begin();
@@ -250,7 +250,7 @@ public:
     /** @brief Subtraction assignment operator for std::initializer_list */
     template <
         typename T2,
-        std::enable_if_t<std::is_arithmetic<T2>::value, bool> = true>
+        std::enable_if_t<std::is_arithmetic_v<T2>, bool> = true>
     auto operator-=(const std::initializer_list<T2>& b) -> Vec&
     {
         auto it = b.begin();
@@ -272,7 +272,7 @@ public:
     /** @brief Multiplication assignment operator */
     template <
         typename T2,
-        std::enable_if_t<std::is_arithmetic<T2>::value, bool> = true>
+        std::enable_if_t<std::is_arithmetic_v<T2>, bool> = true>
     auto operator*=(const T2& b) -> Vec&
     {
         for (auto& v : val_) {
@@ -284,7 +284,7 @@ public:
     /** @brief Vector-scalar multiplication operator */
     template <
         typename T2,
-        std::enable_if_t<std::is_arithmetic<T2>::value, bool> = true>
+        std::enable_if_t<std::is_arithmetic_v<T2>, bool> = true>
     friend auto operator*(Vec lhs, const T2& rhs) -> Vec
     {
         lhs *= rhs;
@@ -294,7 +294,7 @@ public:
     /** @brief Scalar-vector multiplication operator */
     template <
         typename T2,
-        std::enable_if_t<std::is_arithmetic<T2>::value, bool> = true>
+        std::enable_if_t<std::is_arithmetic_v<T2>, bool> = true>
     friend auto operator*(const T2& lhs, Vec rhs) -> Vec
     {
         rhs *= lhs;
@@ -311,7 +311,7 @@ public:
     /** @brief Division assignment operator */
     template <
         typename T2,
-        std::enable_if_t<std::is_arithmetic<T2>::value, bool> = true>
+        std::enable_if_t<std::is_arithmetic_v<T2>, bool> = true>
     auto operator/=(const T2& b) -> Vec&
     {
         for (auto& v : val_) {
@@ -330,7 +330,7 @@ public:
      */
     template <
         typename T2,
-        std::enable_if_t<std::is_arithmetic<T2>::value, bool> = true>
+        std::enable_if_t<std::is_arithmetic_v<T2>, bool> = true>
     friend auto operator/(Vec lhs, const T2& rhs) -> Vec
     {
         lhs /= rhs;
@@ -347,7 +347,7 @@ public:
      */
     template <
         typename T2,
-        std::enable_if_t<std::is_arithmetic<T2>::value, bool> = true>
+        std::enable_if_t<std::is_arithmetic_v<T2>, bool> = true>
     friend auto operator/(const T2& lhs, Vec rhs) -> Vec
     {
         for (auto& v : rhs) {
@@ -369,7 +369,7 @@ public:
      */
     template <
         typename T2,
-        std::enable_if_t<std::is_arithmetic<T2>::value, bool> = true>
+        std::enable_if_t<std::is_arithmetic_v<T2>, bool> = true>
     auto dot(const std::initializer_list<T2>& b) const -> T
     {
         return educelab::dot(val_, b);
@@ -386,7 +386,7 @@ public:
     template <
         typename T2,
         std::size_t D = Dims,
-        std::enable_if_t<std::is_arithmetic<T2>::value, bool> = true>
+        std::enable_if_t<std::is_arithmetic_v<T2>, bool> = true>
     auto cross(const std::initializer_list<T2>& b) const
         -> std::enable_if_t<D == 3, Vec>
     {

--- a/include/educelab/core/utils/Caching.hpp
+++ b/include/educelab/core/utils/Caching.hpp
@@ -8,6 +8,7 @@
 #include <cstddef>
 #include <list>
 #include <mutex>
+#include <optional>
 #include <random>
 #include <shared_mutex>
 #include <unordered_map>

--- a/include/educelab/core/utils/Iteration.hpp
+++ b/include/educelab/core/utils/Iteration.hpp
@@ -411,10 +411,10 @@ template <class Iterable>
 class EnumerateIterable;
 
 template <class Iterable>
-inline auto enumerate(Iterable&& it);
+auto enumerate(Iterable&& it);
 
 template <typename... Args>
-inline auto enumerate(Args&&... args);
+auto enumerate(Args&&... args);
 
 /**
  * @brief Iterable wrapper for enumerating elements of a container by index and
@@ -567,7 +567,7 @@ private:
  * @ingroup Util
  */
 template <class Iterable>
-inline auto enumerate(Iterable&& it)
+auto enumerate(Iterable&& it)
 {
     return EnumerateIterable<Iterable>(std::forward<Iterable>(it));
 }
@@ -589,7 +589,7 @@ inline auto enumerate(Iterable&& it)
  * @ingroup Util
  */
 template <typename... Args>
-inline auto enumerate(Args&&... args)
+auto enumerate(Args&&... args)
 {
     using Type = std::common_type_t<Args...>;
     using Iterable = std::array<Type, sizeof...(Args)>;

--- a/include/educelab/core/utils/Iteration.hpp
+++ b/include/educelab/core/utils/Iteration.hpp
@@ -20,7 +20,7 @@ namespace educelab
  *
  * @ingroup Util
  */
-template <typename T, std::enable_if_t<std::is_arithmetic<T>::value, int> = 0>
+template <typename T, std::enable_if_t<std::is_arithmetic_v<T>, int> = 0>
 class RangeIterable
 {
 private:
@@ -117,15 +117,14 @@ public:
 
     /** Returns the size of the range (floating point ranges) */
     template <typename Q = T>
-    auto size() const
-        -> std::enable_if_t<std::is_floating_point<Q>::value, size_t>
+    auto size() const -> std::enable_if_t<std::is_floating_point_v<Q>, size_t>
     {
         return static_cast<size_t>(std::ceil((end_ - start_) / step_));
     }
 
     /** Returns the size of the range (integral ranges) */
     template <typename Q = T>
-    auto size() const -> std::enable_if_t<std::is_integral<Q>::value, size_t>
+    auto size() const -> std::enable_if_t<std::is_integral_v<Q>, size_t>
     {
         return static_cast<size_t>((end_ - start_) / step_);
     }
@@ -208,7 +207,7 @@ auto range(T0 start, T1 stop, T2 step) -> RangeIterable<T0>
  *
  * @ingroup Util
  */
-template <typename T, std::enable_if_t<std::is_arithmetic<T>::value, int> = 0>
+template <typename T, std::enable_if_t<std::is_arithmetic_v<T>, int> = 0>
 class Range2DIterable
 {
 private:
@@ -326,8 +325,7 @@ public:
 
     /** Returns the size of the range (floating point ranges) */
     template <typename Q = T>
-    auto size() const
-        -> std::enable_if_t<std::is_floating_point<Q>::value, size_t>
+    auto size() const -> std::enable_if_t<std::is_floating_point_v<Q>, size_t>
     {
         auto vLen = static_cast<size_t>(std::ceil((vEnd_ - vStart_) / step_));
         return static_cast<size_t>(std::ceil((uEnd_ - uStart_) / step_)) * vLen;
@@ -335,7 +333,7 @@ public:
 
     /** Returns the size of the range (integral ranges) */
     template <typename Q = T>
-    auto size() const -> std::enable_if_t<std::is_integral<Q>::value, size_t>
+    auto size() const -> std::enable_if_t<std::is_integral_v<Q>, size_t>
     {
         auto vLen = static_cast<size_t>((vEnd_ - vStart_) / step_);
         return static_cast<size_t>((uEnd_ - uStart_) / step_) * vLen;

--- a/include/educelab/core/utils/Iteration.hpp
+++ b/include/educelab/core/utils/Iteration.hpp
@@ -458,7 +458,7 @@ private:
         /** @} */
 
         /** Constructor for the iterator */
-        explicit EnumerateIterator(size_t idx, T&& it)
+        explicit EnumerateIterator(const size_t idx, T&& it)
             : idx_{idx}, it_{std::move(it)}
         {
         }

--- a/include/educelab/core/utils/Math.hpp
+++ b/include/educelab/core/utils/Math.hpp
@@ -36,7 +36,7 @@ template<typename T>
 auto copysign(const T& mag, const T& sgn) -> T
 {
     T o;
-    std::transform(std::begin(mag), std::end(mag), std::begin(sgn), std::begin(o), std::copysign);
+    std::transform(std::begin(mag), std::end(mag), std::begin(sgn), std::begin(o), [](const auto& a, const auto& b) { return std::copysign(a, b); });
     return o;
 }
 

--- a/include/educelab/core/utils/Math.hpp
+++ b/include/educelab/core/utils/Math.hpp
@@ -31,6 +31,15 @@ auto abs(const T& v) -> T
     return o;
 }
 
+/** @brief Per-element copysign */
+template<typename T>
+auto copysign(const T& mag, const T& sgn) -> T
+{
+    T o;
+    std::transform(std::begin(mag), std::end(mag), std::begin(sgn), std::begin(o), std::copysign);
+    return o;
+}
+
 /** @brief Vector dot product (inner product) */
 template <typename T1, typename T2>
 auto dot(const T1& a, const T2& b)

--- a/include/educelab/core/utils/Math.hpp
+++ b/include/educelab/core/utils/Math.hpp
@@ -20,6 +20,17 @@ constexpr T PI =
 template <class T, std::enable_if_t<std::is_floating_point_v<T>, bool> = true>
 constexpr T INF = std::numeric_limits<T>::infinity();
 
+/** @brief Per-element absolute value for container types */
+template <typename T>
+auto abs(const T& v) -> T
+{
+    T o;
+    std::transform(std::begin(v), std::end(v), std::begin(o), [](auto e) {
+        return std::abs(e);
+    });
+    return o;
+}
+
 /** @brief Vector dot product (inner product) */
 template <typename T1, typename T2>
 auto dot(const T1& a, const T2& b)

--- a/include/educelab/core/utils/Math.hpp
+++ b/include/educelab/core/utils/Math.hpp
@@ -91,7 +91,7 @@ enum class Norm {
 
 /** @brief Compute vector norm */
 template <class Vector>
-auto norm(const Vector& v, Norm norm = Norm::L2)
+auto norm(const Vector& v, const Norm norm = Norm::L2)
 {
     using Ret = decltype(*std::begin(v));
     switch (norm) {

--- a/include/educelab/core/utils/Math.hpp
+++ b/include/educelab/core/utils/Math.hpp
@@ -12,16 +12,12 @@ namespace educelab
 {
 
 /** @brief Pi, templated for floating-point type */
-template <
-    class T,
-    std::enable_if_t<std::is_floating_point<T>::value, bool> = true>
+template <class T, std::enable_if_t<std::is_floating_point_v<T>, bool> = true>
 constexpr T PI =
     T(3.141592653589793238462643383279502884198716939937510582097164L);
 
 /** @brief Inf, templated for floating-point type */
-template <
-    class T,
-    std::enable_if_t<std::is_floating_point<T>::value, bool> = true>
+template <class T, std::enable_if_t<std::is_floating_point_v<T>, bool> = true>
 constexpr T INF = std::numeric_limits<T>::infinity();
 
 /** @brief Vector dot product (inner product) */
@@ -65,7 +61,7 @@ auto schur_product(const T1& a, const T2& b) -> T1
 template <
     typename T1,
     typename T2,
-    std::enable_if_t<std::is_arithmetic<T2>::value, bool> = true>
+    std::enable_if_t<std::is_arithmetic_v<T2>, bool> = true>
 auto cross(const T1& a, const std::initializer_list<T2>& b) -> T1
 {
     struct InitList : public std::initializer_list<T2> {
@@ -133,7 +129,7 @@ auto interior_angle(const Vector1& a, const Vector2& b)
 template <
     typename T = float,
     typename T2,
-    std::enable_if_t<std::is_floating_point<T>::value, bool> = true>
+    std::enable_if_t<std::is_floating_point_v<T>, bool> = true>
 constexpr auto to_radians(T2 deg) -> T
 {
     return deg * PI<T> / T(180);
@@ -143,7 +139,7 @@ constexpr auto to_radians(T2 deg) -> T
 template <
     typename T = float,
     typename T2,
-    std::enable_if_t<std::is_floating_point<T>::value, bool> = true>
+    std::enable_if_t<std::is_floating_point_v<T>, bool> = true>
 constexpr auto to_degrees(T2 rad) -> T
 {
     return rad * T(180) / PI<T>;
@@ -168,7 +164,7 @@ auto random(T min = 0, T max = 1) -> T
 /** @brief Check if the given value is almost zero using an absolute epsilon */
 template <
     typename T,
-    std::enable_if_t<std::is_floating_point<T>::value, bool> = true>
+    std::enable_if_t<std::is_floating_point_v<T>, bool> = true>
 auto almost_zero(T v, T eps = 1e-7) -> bool
 {
     return std::abs(v) < eps;
@@ -191,7 +187,7 @@ auto almost_zero(T v, T eps = 1e-7) -> bool
  */
 template <
     typename T,
-    std::enable_if_t<std::is_floating_point<T>::value, bool> = true>
+    std::enable_if_t<std::is_floating_point_v<T>, bool> = true>
 auto solve_quadratic(T a, T b, T c)
 {
     // Zero a means the equation is linear

--- a/include/educelab/core/utils/Math.hpp
+++ b/include/educelab/core/utils/Math.hpp
@@ -170,6 +170,29 @@ auto almost_zero(T v, T eps = 1e-7) -> bool
     return std::abs(v) < eps;
 }
 
+/** @brief Check if two values are almost equal to each other */
+template <
+    typename T,
+    typename T2,
+    std::enable_if_t<std::is_floating_point_v<T>, bool> = true>
+auto almost_equal(
+    const T lhs,
+    const T2 rhs,
+    T epsAbs = 1e-7,
+    T epsRel = std::numeric_limits<T>::epsilon()) -> bool
+{
+    auto rhsT = static_cast<T>(rhs);
+    T d = std::abs(lhs - rhsT);
+    if (d <= epsAbs) {
+        return true;
+    }
+    T l = std::abs(lhs);
+    T r = std::abs(rhsT);
+
+    T largest = std::max(r, l);
+    return d <= largest * epsRel;
+}
+
 /**
  * @brief Solve for the solutions of a quadratic equation
  *

--- a/include/educelab/core/utils/Math.hpp
+++ b/include/educelab/core/utils/Math.hpp
@@ -157,7 +157,7 @@ constexpr auto to_degrees(T2 rad) -> T
  * desirable for all applications.
  */
 template <typename T>
-inline auto random(T min = 0, T max = 1) -> T
+auto random(T min = 0, T max = 1) -> T
 {
     std::uniform_real_distribution<T> distribution(min, max);
     static std::random_device source;
@@ -169,7 +169,7 @@ inline auto random(T min = 0, T max = 1) -> T
 template <
     typename T,
     std::enable_if_t<std::is_floating_point<T>::value, bool> = true>
-inline auto almost_zero(T v, T eps = 1e-7) -> bool
+auto almost_zero(T v, T eps = 1e-7) -> bool
 {
     return std::abs(v) < eps;
 }
@@ -192,7 +192,7 @@ inline auto almost_zero(T v, T eps = 1e-7) -> bool
 template <
     typename T,
     std::enable_if_t<std::is_floating_point<T>::value, bool> = true>
-inline auto solve_quadratic(T a, T b, T c)
+auto solve_quadratic(T a, T b, T c)
 {
     // Zero a means the equation is linear
     if (almost_zero(a)) {

--- a/include/educelab/core/utils/String.hpp
+++ b/include/educelab/core/utils/String.hpp
@@ -83,7 +83,7 @@ static inline void trim_left_in_place(std::string& s)
 }
 
 /** @brief Left trim (copy) */
-static inline auto trim_left_copy(std::string_view s) -> std::string
+static inline auto trim_left_copy(const std::string_view s) -> std::string
 {
     return std::string{trim_left(s)};
 }
@@ -117,7 +117,7 @@ static inline void trim_right_in_place(std::string& s)
 }
 
 /** @brief Right trim (copy) */
-static inline auto trim_right_copy(std::string_view s) -> std::string
+static inline auto trim_right_copy(const std::string_view s) -> std::string
 {
     return std::string{trim_right(s)};
 }
@@ -142,7 +142,7 @@ static inline void trim_in_place(std::string& s)
 }
 
 /** @brief Right trim (copy) */
-static inline auto trim_copy(std::string_view s) -> std::string
+static inline auto trim_copy(const std::string_view s) -> std::string
 {
     return std::string{trim(s)};
 }
@@ -210,7 +210,7 @@ static inline auto split(std::string_view s, const Ds&... ds)
  * @return Converted value
  */
 template <typename T, typename... Args>
-auto to_numeric(std::string_view str, Args... args) -> T
+auto to_numeric(const std::string_view str, Args... args) -> T
 {
     T val;
     const auto* first = std::data(str);
@@ -234,21 +234,21 @@ auto to_numeric(std::string_view str, Args... args) -> T
  * `std::string` and passes to the appropriate `std::sto` function.
  */
 template <>
-inline auto to_numeric<float>(std::string_view str) -> float
+inline auto to_numeric<float>(const std::string_view str) -> float
 {
     return std::stof(std::string(str));
 }
 
 /** @copydoc to_numeric<float> */
 template <>
-inline auto to_numeric<double>(std::string_view str) -> double
+inline auto to_numeric<double>(const std::string_view str) -> double
 {
     return std::stod(std::string(str));
 }
 
 /** @copydoc to_numeric<float> */
 template <>
-inline auto to_numeric<long double>(std::string_view str) -> long double
+inline auto to_numeric<long double>(const std::string_view str) -> long double
 {
     return std::stold(std::string(str));
 }

--- a/include/educelab/core/utils/String.hpp
+++ b/include/educelab/core/utils/String.hpp
@@ -15,49 +15,49 @@ namespace educelab
 {
 
 /** @brief Convert string characters to upper case (in place) */
-static inline void to_upper(std::string& s)
+static void to_upper(std::string& s)
 {
     const auto& f = std::use_facet<std::ctype<char>>(std::locale());
     f.toupper(s.data(), s.data() + s.size());
 }
 
 /** @brief Convert string characters to upper case (r-value) */
-static inline auto to_upper(std::string&& s) -> std::string
+static auto to_upper(std::string&& s) -> std::string
 {
     to_upper(s);
     return std::move(s);
 }
 
 /** @brief Convert string characters to upper case (copy) */
-static inline auto to_upper_copy(std::string s) -> std::string
+static auto to_upper_copy(std::string s) -> std::string
 {
     to_upper(s);
     return s;
 }
 
 /** @brief Convert string characters to lower case (in place) */
-static inline void to_lower(std::string& s)
+static void to_lower(std::string& s)
 {
     const auto& f = std::use_facet<std::ctype<char>>(std::locale());
     f.tolower(s.data(), s.data() + s.size());
 }
 
 /** @brief Convert string characters to lower case (r-value) */
-static inline auto to_lower(std::string&& s) -> std::string
+static auto to_lower(std::string&& s) -> std::string
 {
     to_lower(s);
     return std::move(s);
 }
 
 /** @brief Convert string characters to lower case (copy) */
-static inline auto to_lower_copy(std::string s) -> std::string
+static auto to_lower_copy(std::string s) -> std::string
 {
     to_lower(s);
     return s;
 }
 
 /** @brief Left trim */
-static inline auto trim_left(std::string_view s) -> std::string_view
+static auto trim_left(std::string_view s) -> std::string_view
 {
     const auto& loc = std::locale();
     const auto* start = std::find_if_not(
@@ -72,7 +72,7 @@ static inline auto trim_left(std::string_view s) -> std::string_view
  *
  * https://stackoverflow.com/a/217605
  */
-static inline void trim_left_in_place(std::string& s)
+static void trim_left_in_place(std::string& s)
 {
     const auto& loc = std::locale();
     s.erase(
@@ -83,13 +83,13 @@ static inline void trim_left_in_place(std::string& s)
 }
 
 /** @brief Left trim (copy) */
-static inline auto trim_left_copy(const std::string_view s) -> std::string
+static auto trim_left_copy(const std::string_view s) -> std::string
 {
     return std::string{trim_left(s)};
 }
 
 /** @brief Right trim */
-static inline auto trim_right(std::string_view s) -> std::string_view
+static auto trim_right(std::string_view s) -> std::string_view
 {
     const auto& loc = std::locale();
     const auto* start =
@@ -105,7 +105,7 @@ static inline auto trim_right(std::string_view s) -> std::string_view
  *
  * https://stackoverflow.com/a/217605
  */
-static inline void trim_right_in_place(std::string& s)
+static void trim_right_in_place(std::string& s)
 {
     const auto& loc = std::locale();
     s.erase(
@@ -117,13 +117,13 @@ static inline void trim_right_in_place(std::string& s)
 }
 
 /** @brief Right trim (copy) */
-static inline auto trim_right_copy(const std::string_view s) -> std::string
+static auto trim_right_copy(const std::string_view s) -> std::string
 {
     return std::string{trim_right(s)};
 }
 
 /** @brief Trim from both ends */
-static inline auto trim(std::string_view s) -> std::string_view
+static auto trim(std::string_view s) -> std::string_view
 {
     s = trim_left(s);
     s = trim_right(s);
@@ -135,21 +135,21 @@ static inline auto trim(std::string_view s) -> std::string_view
  *
  * https://stackoverflow.com/a/217605
  */
-static inline void trim_in_place(std::string& s)
+static void trim_in_place(std::string& s)
 {
     trim_left_in_place(s);
     trim_right_in_place(s);
 }
 
 /** @brief Right trim (copy) */
-static inline auto trim_copy(const std::string_view s) -> std::string
+static auto trim_copy(const std::string_view s) -> std::string
 {
     return std::string{trim(s)};
 }
 
 /** @brief Split a string by a delimiter */
 template <typename... Ds>
-static inline auto split(std::string_view s, const Ds&... ds)
+static auto split(std::string_view s, const Ds&... ds)
     -> std::vector<std::string_view>
 {
     // Build delimiters list
@@ -176,15 +176,13 @@ static inline auto split(std::string_view s, const Ds&... ds)
     // Split string
     std::vector<std::string_view> tokens;
     std::string_view::size_type begin{0};
-    for (auto end : delimPos) {
-        auto t = s.substr(begin, end - begin);
-        if (not t.empty()) {
+    for (const auto end : delimPos) {
+        if (auto t = s.substr(begin, end - begin); not t.empty()) {
             tokens.emplace_back(t);
         }
         begin = end + 1;
     }
-    auto t = s.substr(begin);
-    if (not t.empty()) {
+    if (auto t = s.substr(begin); not t.empty()) {
         tokens.emplace_back(t);
     }
 

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -16,7 +16,7 @@ static constexpr float u8_to_f32{1.F / max_u8};
 static constexpr float u16_to_u8{max_u8 / max_u16};
 static constexpr float u16_to_f32{1.F / max_u16};
 
-static inline auto size_of(Depth d) -> std::size_t
+static inline auto size_of(const Depth d) -> std::size_t
 {
     switch (d) {
         case Depth::None:
@@ -95,7 +95,7 @@ void depth_cast<float, std::uint16_t>(const std::byte* in, std::byte* out)
 }
 
 template <typename TIn, typename TOut>
-void pixel_cast(const std::byte* in, std::byte* out, std::size_t cns)
+void pixel_cast(const std::byte* in, std::byte* out, const std::size_t cns)
 {
     for (std::size_t idx{0}; idx < cns; idx++) {
         auto i_idx = idx * sizeof(TIn);
@@ -106,10 +106,10 @@ void pixel_cast(const std::byte* in, std::byte* out, std::size_t cns)
 
 static void convert_pixel(
     const std::byte* in,
-    Depth inType,
+    const Depth inType,
     std::byte* out,
-    Depth outType,
-    std::size_t cns)
+    const Depth outType,
+    const std::size_t cns)
 {
 
     // 8bpc -> 16bpc
@@ -148,7 +148,11 @@ static void convert_pixel(
     }
 }
 
-Image::Image(std::size_t height, std::size_t width, std::size_t cns, Depth type)
+Image::Image(
+    const std::size_t height,
+    const std::size_t width,
+    const std::size_t cns,
+    const Depth type)
     : h_{height}
     , w_{width}
     , cns_{cns}
@@ -188,7 +192,7 @@ void Image::clear()
     data_.clear();
 }
 
-auto Image::Convert(const Image& i, Depth type) -> Image
+auto Image::Convert(const Image& i, const Depth type) -> Image
 {
     // Return if image is already of requested type
     if (i.type() == type) {
@@ -211,7 +215,7 @@ auto Image::Convert(const Image& i, Depth type) -> Image
     return result;
 }
 
-auto Image::Gamma(const Image& i, float gamma) -> Image
+auto Image::Gamma(const Image& i, const float gamma) -> Image
 {
     auto result = Convert(i, Depth::F32);
     for (std::size_t y{0}; y < result.h_; y++) {
@@ -227,13 +231,17 @@ auto Image::Gamma(const Image& i, float gamma) -> Image
     return Convert(result, i.type());
 }
 
-auto Image::convert(Depth type) const -> Image { return Convert(*this, type); }
+auto Image::convert(const Depth type) const -> Image
+{
+    return Convert(*this, type);
+}
 
 auto Image::data() noexcept -> std::byte* { return data_.data(); }
 
 auto Image::data() const noexcept -> const std::byte* { return data_.data(); }
 
-auto Image::unravel_(std::size_t y, std::size_t x) const -> std::size_t
+auto Image::unravel_(const std::size_t y, const std::size_t x) const
+    -> std::size_t
 {
     return (y % h_) * w_ * cns_ * stride_ + x * cns_ * stride_;
 }

--- a/src/Uuid.cpp
+++ b/src/Uuid.cpp
@@ -66,7 +66,7 @@ auto Uuid::string() const -> std::string
     return ss.str();
 }
 
-auto Uuid::FromString(std::string_view str) -> Uuid
+auto Uuid::FromString(const std::string_view str) -> Uuid
 {
     // TODO: 13th character (first digit of 7th byte) is version number
     static std::regex uuidRe{

--- a/src/Uuid.cpp
+++ b/src/Uuid.cpp
@@ -22,7 +22,7 @@ namespace detail
 template <
     class T = std::mt19937,
     std::size_t N = T::state_size * sizeof(typename T::result_type)>
-auto SeededRandomEngine() -> typename std::enable_if<N != 0, T>::type
+auto SeededRandomEngine() -> std::enable_if_t<N != 0, T>
 {
     std::random_device source;
     using ArrayT = std::random_device::result_type;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,9 +2,7 @@
 FetchContent_Declare(
     googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG release-1.11.0
-    CMAKE_CACHE_ARGS
-        -DINSTALL_GTEST:BOOL=OFF
+    GIT_TAG v1.14.0
 )
 
 FetchContent_GetProperties(googletest)

--- a/tests/src/TestCaching.cpp
+++ b/tests/src/TestCaching.cpp
@@ -4,6 +4,7 @@
 #include <atomic>
 #include <chrono>
 #include <memory>
+#include <optional>
 #include <queue>
 #include <thread>
 #include <unordered_set>

--- a/tests/src/TestCaching.cpp
+++ b/tests/src/TestCaching.cpp
@@ -29,7 +29,7 @@ public:
     void start()
     {
         threads_.resize(ts_);
-        for (auto t : range(ts_)) {
+        for (const auto t : range(ts_)) {
             threads_.at(t) = std::thread(&ThreadPool::loop_, this);
         }
     }
@@ -93,19 +93,19 @@ TEST(Caching, SimpleInsertErase)
     Cache cache;
 
     // Insert
-    auto key = cache.insert(10);
+    const auto key = cache.insert(10);
     EXPECT_TRUE(cache.contains(key));
     EXPECT_EQ(cache.count(), 1);
     EXPECT_FALSE(cache.empty());
     EXPECT_EQ(cache.size(), sizeof(int));
 
     // Get
-    auto result = cache.get(key);
+    const auto result = cache.get(key);
     EXPECT_TRUE(result.has_value());
     EXPECT_EQ(std::any_cast<int>(result), 10);
 
     // Erase
-    auto erased = cache.erase(key);
+    const auto erased = cache.erase(key);
     EXPECT_FALSE(cache.contains(key));
     EXPECT_EQ(cache.count(), 0);
     EXPECT_TRUE(cache.empty());
@@ -136,7 +136,7 @@ TEST(Caching, MassInsertClear)
     }
 
     // Clear 50%
-    auto erased = cache.clear(sizeof(int) * 50);
+    const auto erased = cache.clear(sizeof(int) * 50);
     EXPECT_EQ(cache.count(), 50);
     EXPECT_FALSE(cache.empty());
     EXPECT_EQ(erased, sizeof(int) * 50);
@@ -161,7 +161,7 @@ TEST(Caching, UniqueKeys)
     }
 
     // Remove duplicates with unordered_set
-    std::unordered_set<Cache::key_type> set(keys.begin(), keys.end());
+    const std::unordered_set<Cache::key_type> set(keys.begin(), keys.end());
     EXPECT_EQ(set.size(), keys.size());
 }
 
@@ -237,14 +237,14 @@ TEST(Caching, LRUCache)
     }
 
     // Touch the oldest key still in the cache
-    auto keepAlive = keys.at(50);
+    const auto keepAlive = keys.at(50);
     cache.get(keepAlive);
 
     // Insert a new value
-    auto newKey = cache.insert(10);
+    const auto newKey = cache.insert(10);
 
     // Check what was removed
-    auto expectRemoved = keys.at(51);
+    const auto expectRemoved = keys.at(51);
     EXPECT_TRUE(cache.contains(keepAlive));
     EXPECT_TRUE(cache.contains(newKey));
     EXPECT_FALSE(cache.contains(expectRemoved));
@@ -256,18 +256,18 @@ TEST(Caching, SpecializedCache)
     ObjectCache<int> cache;
 
     // Insert
-    auto key = cache.insert(10);
+    const auto key = cache.insert(10);
     EXPECT_TRUE(cache.contains(key));
     EXPECT_EQ(cache.count(), 1);
     EXPECT_FALSE(cache.empty());
     EXPECT_EQ(cache.size(), sizeof(int));
 
     // Get
-    auto result = cache.get(key);
+    const auto result = cache.get(key);
     EXPECT_EQ(result, 10);
 
     // Erase
-    auto erased = cache.erase(key);
+    const auto erased = cache.erase(key);
     EXPECT_FALSE(cache.contains(key));
     EXPECT_EQ(cache.count(), 0);
     EXPECT_TRUE(cache.empty());
@@ -289,11 +289,11 @@ TEST(Caching, DefaultCopy)
 {
     // Create first cache
     ObjectCache<int> a;
-    auto key0 = a.insert(0);
+    const auto key0 = a.insert(0);
 
     // Copy construct
     ObjectCache<int> b(a);
-    auto key1 = b.insert(1);
+    const auto key1 = b.insert(1);
 
     // Test the sizes
     EXPECT_EQ(b.count(), 2);
@@ -304,7 +304,7 @@ TEST(Caching, DefaultCopy)
     // Copy operator
     ObjectCache<int> c;
     c = b;
-    auto key2 = c.insert(2);
+    const auto key2 = c.insert(2);
 
     // Test the sizes
     EXPECT_EQ(c.count(), 3);
@@ -318,11 +318,11 @@ TEST(Caching, DefaultMove)
 {
     // Create first cache
     ObjectCache<int> a;
-    auto key0 = a.insert(0);
+    const auto key0 = a.insert(0);
 
     // Move construct
     ObjectCache<int> b(std::move(a));
-    auto key1 = b.insert(1);
+    const auto key1 = b.insert(1);
 
     // Test the sizes
     EXPECT_EQ(b.count(), 2);
@@ -332,7 +332,7 @@ TEST(Caching, DefaultMove)
     // Move operator
     ObjectCache<int> c;
     c = std::move(b);
-    auto key2 = c.insert(2);
+    const auto key2 = c.insert(2);
 
     // Test the sizes
     EXPECT_EQ(c.count(), 3);
@@ -360,14 +360,14 @@ TEST(Caching, SharedPtr)
     // Check access through the weak_ptr
     {
         EXPECT_TRUE(weak.use_count() != 0);
-        auto shared = weak.lock();
+        const auto shared = weak.lock();
         EXPECT_TRUE(shared);
         EXPECT_EQ(*shared, 10);
     }
 
     // Check access through the cache
     {
-        auto shared = std::any_cast<std::shared_ptr<int>>(cache.get(key));
+        const auto shared = std::any_cast<std::shared_ptr<int>>(cache.get(key));
         EXPECT_TRUE(shared);
         EXPECT_EQ(*shared, 10);
     }
@@ -378,7 +378,7 @@ TEST(Caching, SharedPtr)
     // Check no access through the weak_ptr
     {
         EXPECT_TRUE(weak.use_count() == 0);
-        auto shared = weak.lock();
+        const auto shared = weak.lock();
         EXPECT_FALSE(shared);
     }
 }
@@ -402,7 +402,7 @@ TEST(Caching, Threading)
     for (auto i : range(5'000)) {
         // Try to retrieve one of our starting keys
         pool.push_back([&cache, &keys, &hits, i]() {
-            auto value = cache.find(keys[i]);
+            const auto value = cache.find(keys[i]);
             if (value) {
                 hits++;
             }

--- a/tests/src/TestCaching.cpp
+++ b/tests/src/TestCaching.cpp
@@ -4,7 +4,6 @@
 #include <atomic>
 #include <chrono>
 #include <memory>
-#include <optional>
 #include <queue>
 #include <thread>
 #include <unordered_set>

--- a/tests/src/TestImage.cpp
+++ b/tests/src/TestImage.cpp
@@ -7,7 +7,7 @@ using namespace educelab;
 
 TEST(Image, DefaultConstructor)
 {
-    Image img;
+    const Image img;
     EXPECT_EQ(img.height(), 0);
     EXPECT_EQ(img.width(), 0);
     EXPECT_EQ(img.channels(), 0);
@@ -142,7 +142,7 @@ TEST(Image, Gamma)
     std::array<float, 11> expected;
 
     // Fill image and expected array
-    float gamma{2.F};
+    const float gamma{2.F};
     for (const auto x : range(11)) {
         // Assign to image
         img.at<float>(0, x) = 0.1F * float(x);

--- a/tests/src/TestIteration.cpp
+++ b/tests/src/TestIteration.cpp
@@ -8,7 +8,7 @@ using namespace educelab;
 TEST(Iteration, RangeEndOnly)
 {
     // Construct range and get iterator
-    auto r = range(5);
+    const auto r = range(5);
     auto it = r.begin();
 
     // Do standard loop
@@ -25,7 +25,7 @@ TEST(Iteration, RangeEndOnly)
 TEST(Iteration, RangeStartEnd)
 {
     // Construct range and get iterator
-    auto r = range(1, 5);
+    const auto r = range(1, 5);
     auto it = r.begin();
 
     // Do standard loop
@@ -42,7 +42,7 @@ TEST(Iteration, RangeStartEnd)
 TEST(Iteration, RangeStartEndStep)
 {
     // Construct range and get iterator
-    auto r = range(1, 5, 2);
+    const auto r = range(1, 5, 2);
     auto it = r.begin();
 
     // Do standard loop
@@ -60,7 +60,7 @@ TEST(Iteration, RangeIteratorEquality)
 {
 
     // Construct range and get iterator
-    auto r = range(0, 10, 3);
+    const auto r = range(0, 10, 3);
     auto it = r.begin();
 
     // Make sure nothing prior to the end matches the end
@@ -79,7 +79,7 @@ TEST(Iteration, RangeIteratorEquality)
 TEST(Iteration, Range2DEndOnly)
 {
     // Construct range and get iterator
-    auto r = range2D(5, 5);
+    const auto r = range2D(5, 5);
     auto it = r.begin();
 
     // Do standard 2D loop
@@ -104,7 +104,7 @@ TEST(Iteration, Range2DEndOnly)
 TEST(Iteration, Range2DStartEnd)
 {
     // Construct range and get iterator
-    auto r = range2D(1, 5, 1, 5);
+    const auto r = range2D(1, 5, 1, 5);
     auto it = r.begin();
 
     // Do standard 2D loop
@@ -129,7 +129,7 @@ TEST(Iteration, Range2DStartEnd)
 TEST(Iteration, Range2DStartEndStep)
 {
     // Construct range and get iterator
-    auto r = range2D(1, 6, 1, 6, 2);
+    const auto r = range2D(1, 6, 1, 6, 2);
     auto it = r.begin();
 
     // Do standard 2D loop
@@ -153,14 +153,14 @@ TEST(Iteration, Range2DStartEndStep)
 
 TEST(Iteration, Range2DFloat)
 {
-    float yStart{1.F};
-    float yMax{5.F};
-    float xStart{2.F};
-    float xMax{6.F};
-    float step{.5F};
+    const float yStart{1.F};
+    const float yMax{5.F};
+    const float xStart{2.F};
+    const float xMax{6.F};
+    const float step{.5F};
 
     // Construct range and get iterator
-    auto r = range2D(yStart, yMax, xStart, xMax, step);
+    const auto r = range2D(yStart, yMax, xStart, xMax, step);
     auto it = r.begin();
 
     for (float y = yStart; y < yMax; y += step) {
@@ -184,7 +184,7 @@ TEST(Iteration, Range2DIteratorEquality)
 {
 
     // Construct range and get iterator
-    auto r = range2D(0, 10, 1, 11, 3);
+    const auto r = range2D(0, 10, 1, 11, 3);
     auto it = r.begin();
 
     // Make sure nothing prior to the end matches the end
@@ -225,7 +225,7 @@ TEST(Iteration, EnumerateLVal)
 
 TEST(Iteration, EnumerateRVal)
 {
-    std::vector<int> truth{0, 1, 2, 3, 4};
+    const std::vector<int> truth{0, 1, 2, 3, 4};
     size_t idx{0};
     for (auto pair : enumerate(std::vector<int>{0, 1, 2, 3, 4})) {
         const auto& index = pair.first;
@@ -238,7 +238,7 @@ TEST(Iteration, EnumerateRVal)
 
 TEST(Iteration, EnumerateParamPack)
 {
-    std::vector<int> truth{0, 1, 2, 3, 4};
+    const std::vector<int> truth{0, 1, 2, 3, 4};
     size_t idx{0};
     for (auto pair : enumerate(0, 1, 2, 3, 4)) {
         const auto& index = pair.first;
@@ -251,7 +251,7 @@ TEST(Iteration, EnumerateParamPack)
 
 TEST(Iteration, EnumerateRange)
 {
-    std::vector<int> truth{0, 1, 2, 3, 4};
+    const std::vector<int> truth{0, 1, 2, 3, 4};
     size_t idx{0};
     for (auto pair : enumerate(range(5))) {
         const auto& index = pair.first;

--- a/tests/src/TestLinearAlgebra.cpp
+++ b/tests/src/TestLinearAlgebra.cpp
@@ -9,8 +9,8 @@ using namespace educelab::linalg;
 
 TEST(LinearAlgebra, SolveCramer)
 {
-    Mat<3, 3> A{2, 1, 1, 1, -1, -1, 1, 2, 1};
-    Vec3f b{3, 0, 0};
+    const Mat<3, 3> A{2, 1, 1, 1, -1, -1, 1, 2, 1};
+    const Vec3f b{3, 0, 0};
     Vec3f x;
     EXPECT_NO_THROW(x = solve_cramer(A, b));
     EXPECT_EQ(x, Vec3f(1, -2, 3));
@@ -18,7 +18,7 @@ TEST(LinearAlgebra, SolveCramer)
 
 TEST(LinearAlgebra, SolveCramerError)
 {
-    Mat<3, 3> A{1, 1, 1, 1, 1, 2, 1, 1, 3};
-    Vec3f b{1, 3, -1};
+    const Mat<3, 3> A{1, 1, 1, 1, 1, 2, 1, 1, 3};
+    const Vec3f b{1, 3, -1};
     EXPECT_THROW(solve_cramer(A, b), std::runtime_error);
 }

--- a/tests/src/TestMat.cpp
+++ b/tests/src/TestMat.cpp
@@ -19,7 +19,7 @@ TEST(Mat, DefaultConstructor)
 TEST(Mat, FillConstructor)
 {
     Mat3f m{0, 1, 2, 3, 4, 5, 6, 7, 8};
-    for (auto i : range(9)) {
+    for (const auto i : range(9)) {
         EXPECT_FLOAT_EQ(m.data()[i], float(i));
     }
 }
@@ -78,8 +78,8 @@ TEST(Mat, Eye)
 TEST(Mat, MatrixMatrixMultiplication)
 {
     // Square multiplication
-    Mat<2, 2> m0{1, 2, 3, 4};
-    Mat<2, 2> m1{5, 6, 7, 8};
+    const Mat<2, 2> m0{1, 2, 3, 4};
+    const Mat<2, 2> m1{5, 6, 7, 8};
     auto result = m0 * m1;
 
     // Check result
@@ -89,8 +89,8 @@ TEST(Mat, MatrixMatrixMultiplication)
     }
 
     // Non-square multiplication
-    Mat<2, 3> m2{1, 2, 3, 4, 5, 6};
-    Mat<3, 2> m3{7, 8, 9, 10, 11, 12};
+    const Mat<2, 3> m2{1, 2, 3, 4, 5, 6};
+    const Mat<3, 2> m3{7, 8, 9, 10, 11, 12};
     result = m2 * m3;
 
     // Check result
@@ -105,25 +105,25 @@ TEST(Mat, MatrixVectorMultiplication)
     using Vec4f = Vec<float, 4>;
 
     // Input point
-    Vec4f x{0, 0, 0, 1};
+    const Vec4f x{0, 0, 0, 1};
 
     // Translation matrix
     auto M = Mat<4, 4>::Eye();
     M(0, 3) = 1.F;
     M(1, 3) = 2.F;
     M(2, 3) = 3.F;
-    auto result = M * x;
+    const auto result = M * x;
     EXPECT_EQ(result, Vec4f(1, 2, 3, 1));
 }
 
 TEST(Mat, Determinant2x2)
 {
-    Mat<2, 2> m{1, 2, 3, 4};
+    const Mat<2, 2> m{1, 2, 3, 4};
     EXPECT_FLOAT_EQ(determinant(m), -2.F);
 }
 
 TEST(Mat, Determinant3x3)
 {
-    Mat3f m{1, 2, 3, 4, 5, 6, 7, 8, 9};
+    const Mat3f m{1, 2, 3, 4, 5, 6, 7, 8, 9};
     EXPECT_FLOAT_EQ(determinant(m), 0.F);
 }

--- a/tests/src/TestMath.cpp
+++ b/tests/src/TestMath.cpp
@@ -19,6 +19,18 @@ TEST(Math, Constants)
     EXPECT_DOUBLE_EQ(INF<double>, std::numeric_limits<double>::infinity());
 }
 
+TEST(Math, Abs)
+{
+    EXPECT_EQ(abs(Vec3f{-1, -2, -3}), Vec3f(1, 2, 3));
+}
+
+TEST(Math, CopySign)
+{
+    EXPECT_EQ(copysign(Vec3f{1, 1, 1}, Vec3f{-4, -5, -6}), Vec3f(-1, -1, -1));
+    EXPECT_EQ(copysign(Vec3f{-1, -1, -1}, Vec3f{4, 5, 6}), Vec3f(1, 1, 1));
+    EXPECT_EQ(copysign(Vec3f{1, -1, 1}, Vec3f{-4, 5, -6}), Vec3f(-1, 1, -1));
+}
+
 TEST(Math, DotProduct)
 {
     EXPECT_EQ(dot(Vec3f{1, 0, 0}, Vec3f{0, 1, 0}), 0);
@@ -107,6 +119,13 @@ TEST(Math, AlmostZero)
 {
     EXPECT_TRUE(almost_zero(1e-8F));
     EXPECT_FALSE(almost_zero(1e-7F));
+}
+
+TEST(Math, AlmostEqual)
+{
+    EXPECT_TRUE(almost_equal(1e-6f, 1.1e-6f));
+    EXPECT_TRUE(almost_equal(1.0000001f, 1.00000015f));
+    EXPECT_TRUE(almost_equal(2.0000001f, 2.00000015f));
 }
 
 TEST(Math, SolveQuadraticReal)

--- a/tests/src/TestMath.cpp
+++ b/tests/src/TestMath.cpp
@@ -53,7 +53,7 @@ TEST(Math, CrossProduct)
 
 TEST(Math, Norm)
 {
-    Vec3f vec{1, 0, 0};
+    const Vec3f vec{1, 0, 0};
     EXPECT_EQ(norm(vec, Norm::L1), 1.f);
     EXPECT_EQ(norm(vec, Norm::L2), 1.f);
     EXPECT_EQ(norm(vec, Norm::LInf), 1.f);
@@ -130,7 +130,7 @@ TEST(Math, AlmostEqual)
 
 TEST(Math, SolveQuadraticReal)
 {
-    if (auto res = solve_quadratic(5.F, 6.F, 1.F)) {
+    if (const auto res = solve_quadratic(5.F, 6.F, 1.F)) {
         EXPECT_FLOAT_EQ(res.t0, -1.F);
         EXPECT_FLOAT_EQ(res.t1, -0.2F);
     }
@@ -148,8 +148,8 @@ TEST(Math, SolveQuadraticLinear)
 
 TEST(Math, SchurProduct)
 {
-    Vec3f a{1, 2, 3};
-    Vec3f b{4, 5, 6};
-    auto result = schur_product(a, b);
+    const Vec3f a{1, 2, 3};
+    const Vec3f b{4, 5, 6};
+    const auto result = schur_product(a, b);
     EXPECT_EQ(result, Vec3f(4, 10, 18));
 }

--- a/tests/src/TestMesh.cpp
+++ b/tests/src/TestMesh.cpp
@@ -74,12 +74,12 @@ TEST(Mesh, AddVerticesAndFace)
 {
     // Build mesh
     Mesh3f mesh;
-    std::vector<float> expectedVerts{10, 12, 13};
+    const std::vector<float> expectedVerts{10, 12, 13};
     Mesh3f::Face expectedFace;
     for (const auto& i : expectedVerts) {
         expectedFace.emplace_back(mesh.insertVertex(i, i, i));
     }
-    auto faceIdx = mesh.insertFace(expectedFace);
+    const auto faceIdx = mesh.insertFace(expectedFace);
 
     // Check vertices
     Vec3f expected;

--- a/tests/src/TestSignals.cpp
+++ b/tests/src/TestSignals.cpp
@@ -169,7 +169,7 @@ TEST(Signals, PointerParameterFn)
     Signal<int*> signal;
     signal.connect(FreeFnIntPtrSlot);
 
-    auto val = std::make_unique<int>();
+    const auto val = std::make_unique<int>();
     signal.send(val.get());
     EXPECT_EQ(*val, 1);
 }
@@ -180,7 +180,7 @@ TEST(Signals, Sendlval)
     Signal<size_t> signal;
     signal.connect([&val](size_t v) { val = v; });
 
-    size_t i{1};
+    const size_t i{1};
     signal(i);
 
     EXPECT_EQ(val, 1);

--- a/tests/src/TestString.cpp
+++ b/tests/src/TestString.cpp
@@ -15,14 +15,14 @@ TEST(String, ToUpperInPlace)
 
 TEST(String, ToUpperRValue)
 {
-    auto result = to_upper("This is only a test.");
+    const auto result = to_upper("This is only a test.");
     EXPECT_EQ(result, "THIS IS ONLY A TEST.");
 }
 
 TEST(String, ToUpperCopy)
 {
-    std::string input{"This is only a test."};
-    auto result = to_upper_copy(input);
+    const std::string input{"This is only a test."};
+    const auto result = to_upper_copy(input);
     EXPECT_EQ(input, "This is only a test.");
     EXPECT_EQ(result, "THIS IS ONLY A TEST.");
 }
@@ -36,21 +36,21 @@ TEST(String, ToLowerInPlace)
 
 TEST(String, ToLowerRValue)
 {
-    auto result = to_lower("This is only a test.");
+    const auto result = to_lower("This is only a test.");
     EXPECT_EQ(result, "this is only a test.");
 }
 
 TEST(String, ToLowerCopy)
 {
-    std::string input{"This is only a test."};
-    auto result = to_lower_copy(input);
+    const std::string input{"This is only a test."};
+    const auto result = to_lower_copy(input);
     EXPECT_EQ(input, "This is only a test.");
     EXPECT_EQ(result, "this is only a test.");
 }
 
 TEST(String, TrimLeft)
 {
-    std::string input{"    This is only a test.    "};
+    const std::string input{"    This is only a test.    "};
     auto result = trim_left(input);
     EXPECT_NE(result, input);
     EXPECT_EQ(result, "This is only a test.    ");
@@ -68,15 +68,15 @@ TEST(String, TrimLeftInPlace)
 
 TEST(String, TrimLeftCopy)
 {
-    std::string input{"    This is only a test.    "};
-    auto result = trim_left_copy(input);
+    const std::string input{"    This is only a test.    "};
+    const auto result = trim_left_copy(input);
     EXPECT_EQ(input, "    This is only a test.    ");
     EXPECT_EQ(result, "This is only a test.    ");
 }
 
 TEST(String, TrimRight)
 {
-    std::string input{"    This is only a test.    "};
+    const std::string input{"    This is only a test.    "};
     auto result = trim_right(input);
     EXPECT_NE(result, input);
     EXPECT_EQ(result, "    This is only a test.");
@@ -94,15 +94,15 @@ TEST(String, TrimRightInPlace)
 
 TEST(String, TrimRightCopy)
 {
-    std::string input{"    This is only a test.    "};
-    auto result = trim_right_copy(input);
+    const std::string input{"    This is only a test.    "};
+    const auto result = trim_right_copy(input);
     EXPECT_EQ(input, "    This is only a test.    ");
     EXPECT_EQ(result, "    This is only a test.");
 }
 
 TEST(String, Trim)
 {
-    std::string input{"    This is only a test.    "};
+    const std::string input{"    This is only a test.    "};
     auto result = trim(input);
     EXPECT_NE(result, input);
     EXPECT_EQ(result, "This is only a test.");
@@ -120,8 +120,8 @@ TEST(String, TrimInPlace)
 
 TEST(String, TrimCopy)
 {
-    std::string input{"    This is only a test.    "};
-    auto result = trim_copy(input);
+    const std::string input{"    This is only a test.    "};
+    const auto result = trim_copy(input);
     EXPECT_EQ(input, "    This is only a test.    ");
     EXPECT_EQ(result, "This is only a test.");
 }

--- a/tests/src/TestUuid.cpp
+++ b/tests/src/TestUuid.cpp
@@ -6,23 +6,23 @@ using namespace educelab;
 
 TEST(Uuid, Default)
 {
-    Uuid uuid;
+    const Uuid uuid;
     EXPECT_TRUE(uuid.is_nil());
 }
 
 TEST(Uuid, StringFunctions)
 {
     // Construct a uuid from a known string
-    std::string uuidStr{"2d243fb2-91c8-48ef-beb7-fb60966b2316"};
-    auto uuid = Uuid::FromString(uuidStr);
+    const std::string uuidStr{"2d243fb2-91c8-48ef-beb7-fb60966b2316"};
+    const auto uuid = Uuid::FromString(uuidStr);
     EXPECT_FALSE(uuid.is_nil());
 
     // Get the string back from the new Uuid
-    auto str = uuid.string();
+    const auto str = uuid.string();
     EXPECT_EQ(str, uuidStr);
 
     // Construct a new Uuid from the provided string
-    auto uuidClone = Uuid::FromString(str);
+    const auto uuidClone = Uuid::FromString(str);
     EXPECT_FALSE(uuidClone.is_nil());
     EXPECT_EQ(uuid, uuidClone);
 }

--- a/tests/src/TestVec.cpp
+++ b/tests/src/TestVec.cpp
@@ -7,7 +7,7 @@ using namespace educelab;
 TEST(Vec, OperatorPlus)
 {
     Vec3f a{1, 1, 1};
-    Vec3f b{1, 1, 1};
+    const Vec3f b{1, 1, 1};
     EXPECT_EQ(a + b, Vec3f(2, 2, 2));
     EXPECT_EQ(a, Vec3f(1, 1, 1));
     EXPECT_EQ(b, Vec3f(1, 1, 1));
@@ -22,7 +22,7 @@ TEST(Vec, OperatorPlus)
 TEST(Vec, OperatorMinus)
 {
     Vec3f a{1, 1, 1};
-    Vec3f b{1, 1, 1};
+    const Vec3f b{1, 1, 1};
     EXPECT_EQ(a - b, Vec3f(0, 0, 0));
     EXPECT_EQ(a, Vec3f(1, 1, 1));
     EXPECT_EQ(b, Vec3f(1, 1, 1));
@@ -100,7 +100,7 @@ TEST(Vec, Magnitude2)
 
 TEST(Vec, UnitVector)
 {
-    Vec3f a{2, 0, 0};
+    const Vec3f a{2, 0, 0};
     EXPECT_EQ(a.unit(), Vec3f(1, 0, 0));
     EXPECT_EQ(a, Vec3f(2, 0, 0));
 }


### PR DESCRIPTION
## New
- (math) `almost_equal` and per-element `abs` and `copysign`, including tests.

## Cleanup
- Remove redundant identifiers (e.g. `inline` for template functions)
- Add `const` to variables that can benefit from it
- Simplify template expressions (e.g. `std::is_arithmetic<float>::value` -> `std::is_arithmetic_v<float>`)

## Updates
- Google Test v 1.14.0
- Add GitHub test workflow