### PR TITLE
(utils) Add Flags helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ following files can be installed in this way:
 - `utils/Filesystem.hpp`
     - Requires:
       - `utils/String.hpp`
+- `utils/Flags.hpp`
 - `utils/LinearAlgebra.hpp`
     - Requires:
       - `utils/Math.hpp`

--- a/include/educelab/core/utils/Flags.hpp
+++ b/include/educelab/core/utils/Flags.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+/**
+ * @file
+ *
+ * @brief Helper functions for bitmask flags
+ *
+ * Assumes that the flag type implements the BitmaskType named requirement and
+ * that the unset flag value is 0.
+ */
+
+namespace educelab::flag
+{
+
+/** @brief Returns whether all provided flags are set on the value */
+template <typename T, typename... Ts>
+auto is_set(const T& value, const T& flag, Ts&&... flags) -> bool
+{
+    auto res = (value & flag) == flag;
+    ((res &= (value & flags) == flags), ...);
+    return res;
+}
+
+/** @brief Returns whether any flag is set on the value */
+template <typename T>
+auto is_set(const T& value) -> bool
+{
+    return value != T{0};
+}
+
+/** @brief Sets all given flags on the value */
+template <typename T, typename... Ts>
+void set(T& value, const T& flag, Ts&&... flags)
+{
+    value |= flag;
+    ((value |= flags), ...);
+}
+
+/** @brief Removes all given flags from the value */
+template <typename T, typename... Ts>
+void unset(T& value, const T& flag, Ts&&... flags)
+{
+    value &= ~flag;
+    ((value &= ~flags), ...);
+}
+
+/** @brief Removes all flags from the value */
+template <typename T>
+void unset(T& value)
+{
+    value = 0;
+}
+
+/** @brief Flips all given flags on the value */
+template <typename T, typename... Ts>
+void flip(T& value, const T& flag, Ts&&... flags)
+{
+    value ^= flag;
+    ((value ^= flags), ...);
+}
+
+}  // namespace educelab::flag

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ set(tests
     src/TestCaching.cpp
     src/TestColor.cpp
     src/TestFilesystem.cpp
+    src/TestFlags.cpp
     src/TestImage.cpp
     src/TestIteration.cpp
     src/TestLinearAlgebra.cpp

--- a/tests/src/TestFlags.cpp
+++ b/tests/src/TestFlags.cpp
@@ -1,0 +1,133 @@
+#include <gtest/gtest.h>
+
+#include <bitset>
+
+#include "educelab/core/utils/Flags.hpp"
+
+using namespace educelab;
+
+using Flag = std::bitset<4>;
+static constexpr Flag NONE = 0;
+static constexpr Flag OPTA = 1;
+static constexpr Flag OPTB = 2;
+static constexpr Flag OPTC = 4;
+
+TEST(Flags, IsSet)
+{
+    Flag flag{NONE};
+    EXPECT_FALSE(flag::is_set(flag));
+    EXPECT_FALSE(flag::is_set(flag, OPTA));
+    EXPECT_FALSE(flag::is_set(flag, OPTB));
+    EXPECT_FALSE(flag::is_set(flag, OPTC));
+
+    flag = OPTA;
+    EXPECT_TRUE(flag::is_set(flag));
+    EXPECT_TRUE(flag::is_set(flag, OPTA));
+    EXPECT_FALSE(flag::is_set(flag, OPTA, OPTB, OPTC));
+
+    flag = OPTA | OPTB;
+    EXPECT_FALSE(flag::is_set(flag, OPTA, OPTB, OPTC));
+
+    flag = OPTA | OPTB | OPTC;
+    EXPECT_TRUE(flag::is_set(flag, OPTA, OPTB, OPTC));
+}
+
+TEST(Flags, SetSingle)
+{
+    Flag flag{NONE};
+    flag::set(flag, OPTA);
+    EXPECT_TRUE(flag::is_set(flag));
+    EXPECT_TRUE(flag::is_set(flag, OPTA));
+    EXPECT_FALSE(flag::is_set(flag, OPTB));
+    EXPECT_FALSE(flag::is_set(flag, OPTC));
+
+    flag::set(flag, OPTB);
+    EXPECT_TRUE(flag::is_set(flag));
+    EXPECT_TRUE(flag::is_set(flag, OPTA));
+    EXPECT_TRUE(flag::is_set(flag, OPTB));
+    EXPECT_FALSE(flag::is_set(flag, OPTC));
+
+    flag::set(flag, OPTC);
+    EXPECT_TRUE(flag::is_set(flag));
+    EXPECT_TRUE(flag::is_set(flag, OPTA));
+    EXPECT_TRUE(flag::is_set(flag, OPTB));
+    EXPECT_TRUE(flag::is_set(flag, OPTC));
+}
+
+TEST(Flags, SetMultiple)
+{
+    Flag flag{NONE};
+    flag::set(flag, OPTA, OPTB, OPTC);
+    EXPECT_TRUE(flag::is_set(flag));
+    EXPECT_TRUE(flag::is_set(flag, OPTA));
+    EXPECT_TRUE(flag::is_set(flag, OPTB));
+    EXPECT_TRUE(flag::is_set(flag, OPTC));
+}
+
+TEST(Flags, UnsetSingle)
+{
+    Flag flag{OPTA | OPTB | OPTC};
+    flag::unset(flag, OPTA);
+    EXPECT_TRUE(flag::is_set(flag));
+    EXPECT_FALSE(flag::is_set(flag, OPTA));
+    EXPECT_TRUE(flag::is_set(flag, OPTB));
+    EXPECT_TRUE(flag::is_set(flag, OPTC));
+
+    flag::unset(flag, OPTB);
+    EXPECT_TRUE(flag::is_set(flag));
+    EXPECT_FALSE(flag::is_set(flag, OPTA));
+    EXPECT_FALSE(flag::is_set(flag, OPTB));
+    EXPECT_TRUE(flag::is_set(flag, OPTC));
+
+    flag::unset(flag, OPTC);
+    EXPECT_FALSE(flag::is_set(flag));
+    EXPECT_FALSE(flag::is_set(flag, OPTA));
+    EXPECT_FALSE(flag::is_set(flag, OPTB));
+    EXPECT_FALSE(flag::is_set(flag, OPTC));
+}
+
+TEST(Flags, UnsetMultiple)
+{
+    Flag flag{OPTA | OPTB | OPTC};
+    flag::unset(flag, OPTA, OPTB, OPTC);
+    EXPECT_FALSE(flag::is_set(flag));
+    EXPECT_FALSE(flag::is_set(flag, OPTA));
+    EXPECT_FALSE(flag::is_set(flag, OPTB));
+    EXPECT_FALSE(flag::is_set(flag, OPTC));
+}
+
+TEST(Flags, UnsetAll)
+{
+    Flag flag{OPTA | OPTB | OPTC};
+    flag::unset(flag);
+    EXPECT_FALSE(flag::is_set(flag));
+    EXPECT_FALSE(flag::is_set(flag, OPTA));
+    EXPECT_FALSE(flag::is_set(flag, OPTB));
+    EXPECT_FALSE(flag::is_set(flag, OPTC));
+}
+
+TEST(Flags, FlipSingle)
+{
+    Flag flag;
+    flag::flip(flag, OPTA);
+    EXPECT_TRUE(flag::is_set(flag));
+    EXPECT_TRUE(flag::is_set(flag, OPTA));
+
+    flag::flip(flag, OPTA);
+    EXPECT_FALSE(flag::is_set(flag));
+    EXPECT_FALSE(flag::is_set(flag, OPTA));
+}
+
+TEST(Flags, FlipMultiple)
+{
+    Flag flag{OPTB};
+    flag::flip(flag, OPTA, OPTB, OPTC);
+    EXPECT_TRUE(flag::is_set(flag, OPTA));
+    EXPECT_FALSE(flag::is_set(flag, OPTB));
+    EXPECT_TRUE(flag::is_set(flag, OPTC));
+
+    flag::flip(flag, OPTA, OPTB, OPTC);
+    EXPECT_FALSE(flag::is_set(flag, OPTA));
+    EXPECT_TRUE(flag::is_set(flag, OPTB));
+    EXPECT_FALSE(flag::is_set(flag, OPTC));
+}


### PR DESCRIPTION
Adds helper utilities for types which implement the [BitmaskType named requirement](https://en.cppreference.com/w/cpp/named_req/BitmaskType).

```c++
#include <educelab/core/utils/Flags.hpp>

// Create a flag type
using Flag = std::uint32_t;
static constexpr Flag OptA = 1;
static constexpr Flag OptB = 2;
static constexpr Flag OptC = 4;

namespace el = educelab;

// Flag value
Flag f;

// Has any flag set
el::flag::is_set(f);
// Has specific flag set
el::flag::is_set(f, OptA);
// Has all given flags set
el::flag::is_set(f, OptA, OptB);

// Set a single flag
el::flag::set(f, OptA);
// Set multiple flag values
el::flag::set(f, OptB, OptC);

// Unset a single flag
el::flag::unset(f, OptA);
// Unset multiple flag values
el::flag::unset(f, OptB, OptC);

// Flip a single flag
el::flag::flip(f, OptA);
// Flip multiple flag values
el::flag::flip(f, OptB, OptC);
```