### PR TITLE
Generalize Mat×Vec operator* to support mixed scalar types

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -10,7 +10,7 @@ jobs:
   build_and_test:
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, macos-13, macos-14, macos-15]
+        os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15, macos-26]
     runs-on: ${{ matrix.os }}
     env:
       EXTRA_CMAKE_FLAGS: -DCMAKE_BUILD_TYPE=Release -DEDUCE_CORE_BUILD_TESTS=ON -DEDUCE_CORE_BUILD_EXAMPLES=ON

--- a/include/educelab/core/types/Mat.hpp
+++ b/include/educelab/core/types/Mat.hpp
@@ -116,10 +116,10 @@ auto operator*(const Mat<M, N, T1>& A, const Mat<N, P, T2>& B) -> Mat<M, P, T1>
 }
 
 /** @brief Matrix-vector multiplication */
-template <typename T1, typename T2, std::size_t M, std::size_t N>
-auto operator*(const Mat<M, N, T1>& mat, const Vec<T2, N>& vec) -> Vec<T1, N>
+template <typename T, typename Vector, std::size_t M, std::size_t N>
+auto operator*(const Mat<M, N, T>& mat, const Vector& vec) -> Vector
 {
-    Vec<T1, N> res;
+    Vector res;
     for (std::size_t m{0}; m < M; m++) {
         for (std::size_t n{0}; n < N; n++) {
             res[m] += mat(m, n) * vec[n];

--- a/include/educelab/core/types/Mat.hpp
+++ b/include/educelab/core/types/Mat.hpp
@@ -116,10 +116,10 @@ auto operator*(const Mat<M, N, T1>& A, const Mat<N, P, T2>& B) -> Mat<M, P, T1>
 }
 
 /** @brief Matrix-vector multiplication */
-template <typename T, typename Vector, std::size_t M, std::size_t N>
-auto operator*(const Mat<M, N, T>& mat, const Vector& vec) -> Vector
+template <typename T1, typename T2, std::size_t M, std::size_t N>
+auto operator*(const Mat<M, N, T1>& mat, const Vec<T2, N>& vec) -> Vec<T1, N>
 {
-    Vector res;
+    Vec<T1, N> res;
     for (std::size_t m{0}; m < M; m++) {
         for (std::size_t n{0}; n < N; n++) {
             res[m] += mat(m, n) * vec[n];

--- a/include/educelab/core/types/Mat.hpp
+++ b/include/educelab/core/types/Mat.hpp
@@ -26,7 +26,7 @@ public:
     static constexpr std::size_t cols{Cols};
 
     /** Default constructor */
-    Mat() { vals_.fill(0); };
+    Mat() { vals_.fill(0); }
 
     /** @brief Constructor with fill values */
     template <typename... Args>

--- a/include/educelab/core/utils/String.hpp
+++ b/include/educelab/core/utils/String.hpp
@@ -197,7 +197,7 @@ static auto split(std::string_view s, const Ds&... ds)
     // Split string
     std::vector<std::string_view> tokens;
     std::string_view::size_type begin{0};
-    for (const auto [end, size] : delimPos) {
+    for (const auto& [end, size] : delimPos) {
         // ignore nested delimiters
         if (end < begin) {
             continue;


### PR DESCRIPTION
The matrix-vector `operator*` was overly generic, accepting any `Vector` type, which obscured intent and prevented mixed-type scalar multiplication.

## Changes

- **`Mat.hpp`**: Replace unconstrained `Vector` template parameter with explicit `Vec<T2, N>`, returning `Vec<T1, N>` (matrix scalar type). Enables multiplying a `Mat<M,N,T1>` by a `Vec<T2,N>` with differing scalar types.
  ```cpp
  // Now supported:
  Mat<4, 4, double> m{...};
  Vec<float, 4> v{...};
  auto result = m * v;  // Vec<double, 4>
  ```
- **`Mat.hpp`**: Remove spurious trailing semicolon from default constructor.
- **`String.hpp`**: Take structured binding by `const&` in `split()` range loop to avoid unnecessary copies.
