### PR TITLE
feat(UVMap): per-wedge UV/UVW coordinate store

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ set(public_hdrs
     include/educelab/core/types/Mat.hpp
     include/educelab/core/types/Mesh.hpp
     include/educelab/core/types/Signals.hpp
+    include/educelab/core/types/UVMap.hpp
     include/educelab/core/types/Uuid.hpp
     include/educelab/core/types/Vec.hpp
     include/educelab/core/utils/Caching.hpp

--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ following files can be installed in this way:
     - Requires:
       - `types/Vec.hpp`
       - `types/Color.hpp`
+- `types/UVMap.hpp`
+    - Requires:
+      - `types/Vec.hpp`
 
 
 ## Usage
@@ -111,6 +114,90 @@ std::cout << p << "\n";          // [1, 2, 3, 1]
 
 See [examples/MatExample.cpp](examples/MatExample.cpp) for more usage
 examples.
+
+### Mesh class
+
+```c++
+#include "educelab/core/types/Mesh.hpp"
+
+// Default mesh: 3D float positions, no extra traits
+Mesh<float, 3> mesh;
+
+auto v0 = mesh.insert_vertex(0.F, 0.F, 0.F);
+auto v1 = mesh.insert_vertex(1.F, 0.F, 0.F);
+auto v2 = mesh.insert_vertex(1.F, 1.F, 0.F);
+auto v3 = mesh.insert_vertex(0.F, 1.F, 0.F);
+
+// N-gon faces are supported
+auto f0 = mesh.insert_face(v0, v1, v2, v3);
+
+std::cout << mesh.vertex(v0) << "\n";       // [0, 0, 0]
+std::cout << mesh.face_normal(f0) << "\n";  // [0, 0, 1]
+
+// Adjacency index (lazy, cached)
+for (auto fi : mesh.vertex_faces(v1)) {
+    std::cout << "face " << fi << "\n";     // face 0
+}
+```
+
+Opt-in per-vertex traits compose via multiple inheritance:
+
+```c++
+#include "educelab/core/types/Mesh.hpp"
+
+struct MyTraits : traits::WithNormal<float, 3>, traits::WithColor {};
+using RichMesh = Mesh<float, 3, MyTraits>;
+
+RichMesh rich;
+auto v = rich.insert_vertex(0.F, 0.F, 0.F);
+rich.vertex(v).normal = Vec3f{0.F, 0.F, 1.F};
+rich.vertex(v).color  = Color::U8C3{255, 0, 0};
+```
+
+See [examples/MeshExample.cpp](examples/MeshExample.cpp) for more usage examples.
+
+### UVMap class
+
+`UVMap` stores per-wedge UV coordinates as a flat coordinate pool plus a
+per-face, per-corner index into that pool — mirroring the OBJ/PLY `vt` index
+structure. Multiple corners may reference the same pool entry; the same vertex
+can map to different UVs in adjacent faces (seam support).
+
+```c++
+#include "educelab/core/types/UVMap.hpp"
+
+UVMap<float, 2> uvmap;
+
+// Insert coordinates into the pool
+auto uv0 = uvmap.insert(0.0F, 0.0F);
+auto uv1 = uvmap.insert(1.0F, 0.0F);
+auto uv2 = uvmap.insert(1.0F, 1.0F);
+
+// Assign pool entries to wedges (face, corner, pool index)
+uvmap.map(0, 0, uv0);
+uvmap.map(0, 1, uv1);
+uvmap.map(0, 2, uv2);
+
+// Look up the coordinate for a wedge
+const auto& c = uvmap.get_coordinate(0, 2);
+std::cout << "[" << c[0] << ", " << c[1] << "]\n";  // [1, 1]
+```
+
+Attach a chart index to each coordinate for multi-texture atlases:
+
+```c++
+using ChartedUVMap = UVMap<float, 2, traits::WithChart>;
+ChartedUVMap charted;
+
+ChartedUVMap::Coordinate c(0.25F, 0.25F);
+c.chart = 1;
+auto idx = charted.insert(c);
+charted.map(0, 0, idx);
+
+std::cout << charted.get_coordinate(0, 0).chart << "\n";  // 1
+```
+
+See [examples/MeshExample.cpp](examples/MeshExample.cpp) for more usage examples.
 
 ### Image class
 

--- a/conductor/tracks.md
+++ b/conductor/tracks.md
@@ -3,7 +3,7 @@
 | Status | Track ID | Title | Created | Updated |
 | ------ | -------- | ----- | ------- | ------- |
 | [x] | mesh-redesign_20260320 | Mesh Class Redesign | 2026-03-20 | 2026-03-23 |
-| [ ] | uv-map_20260323 | UVMap | 2026-03-23 | 2026-03-23 |
+| [~] | uv-map_20260323 | UVMap | 2026-03-23 | 2026-03-24 |
 | [!] | mesh-io_20260323 | Mesh IO (blocked) | 2026-03-23 | 2026-03-23 |
 
 <!-- Tracks registered by /conductor:new-track -->

--- a/conductor/tracks.md
+++ b/conductor/tracks.md
@@ -3,7 +3,7 @@
 | Status | Track ID | Title | Created | Updated |
 | ------ | -------- | ----- | ------- | ------- |
 | [x] | mesh-redesign_20260320 | Mesh Class Redesign | 2026-03-20 | 2026-03-23 |
-| [~] | uv-map_20260323 | UVMap | 2026-03-23 | 2026-03-24 |
+| [x] | uv-map_20260323 | UVMap | 2026-03-23 | 2026-03-24 |
 | [!] | mesh-io_20260323 | Mesh IO (blocked) | 2026-03-23 | 2026-03-23 |
 
 <!-- Tracks registered by /conductor:new-track -->

--- a/conductor/tracks/mesh-io_20260323/plan.md
+++ b/conductor/tracks/mesh-io_20260323/plan.md
@@ -8,10 +8,12 @@
 ## Overview
 
 **Blocked on:** `mesh-redesign_20260320` (composable traits) and
-`uv-map_20260323` (UVMap). Do not begin until both are merged.
+`uv-map_20260323` (UVMap + WithChart). Do not begin until both are merged.
 
 Three phases: first establish the detection idiom infrastructure shared by
-all IO headers, then implement OBJ IO, then PLY IO.
+all IO headers, then implement OBJ IO (including MTL texture path handling),
+then PLY IO (including `comment TextureFile` texture path handling and the
+seam-expansion adapter).
 
 ## Checkpoints
 
@@ -49,41 +51,56 @@ implementations readable.
 
 ## Phase 2: OBJ IO
 
-Implement `include/educelab/core/io/MeshIO.hpp` with `readOBJ` and `writeOBJ`.
+Implement `include/educelab/core/io/MeshIO.hpp` with `readOBJ` and `writeOBJ`,
+including MTL texture path read/write.
 
 ### Tasks
 
 - [ ] **Task 2.1**: Write round-trip tests for OBJ in `TestMeshIO.cpp` —
-      cover: positions only, positions + normals (`WithNormal` mesh), positions
-      + colors (`WithColor` mesh), positions + UVs (with `UVMap`), N-gon faces,
-      mesh type without normals reading a file that has normals (normals
-      ignored), missing file error
+      cover: positions only; positions + normals (`WithNormal` mesh); positions
+      + colors (`WithColor` mesh); positions + UVs (no texture); positions +
+      UVs + single texture path (verify `.mtl` written and path round-trips);
+      positions + UVs + multi-chart texture paths via `WithChart` (verify
+      per-chart `usemtl` grouping and path recovery); N-gon faces; mesh type
+      without normals reading a file that has normals (normals ignored);
+      missing file error; `.mtl` present but no `map_Kd` (empty texturePaths)
 - [ ] **Task 2.2**: Implement `writeOBJ(path, mesh)` — writes `v` lines;
       conditionally writes `vn` lines (`if constexpr has_normal`); conditionally
-      writes `vc` lines (`if constexpr has_color`); writes `f` lines with
-      appropriate index syntax
-- [ ] **Task 2.3**: Implement `writeOBJ(path, mesh, uvmap)` overload — adds
-      `vt` lines and per-wedge UV indices in `f` lines; writes minimal `.mtl`
-      referencing a texture path if provided
-- [ ] **Task 2.4**: Implement `readOBJ(path, mesh)` — parses `v`, `vn`, `f`;
-      populates normals via `if constexpr`; returns optional texture path from
-      `.mtl` if present
-- [ ] **Task 2.5**: Implement `readOBJ(path, mesh, uvmap)` overload — also
-      parses `vt` and per-wedge UV indices from `f` lines; populates `uvmap`
-- [ ] **Task 2.6**: Register `TestMeshIO` in `tests/CMakeLists.txt`; add
+      writes `vc` lines (`if constexpr has_color`); writes `f` lines
+- [ ] **Task 2.3**: Implement `writeOBJ(path, mesh, uvmap)` — adds `vt` lines
+      and per-wedge UV indices in `f` lines; no `.mtl` emitted
+- [ ] **Task 2.4**: Implement `writeOBJ(path, mesh, uvmap, texturePath)` —
+      single `std::filesystem::path` overload; emits a `.mtl` with one material
+      (`newmtl material0`, `map_Kd <path>`); all faces prefixed with
+      `usemtl material0`
+- [ ] **Task 2.5**: Implement `writeOBJ(path, mesh, uvmap, texturePaths)` —
+      `std::vector<std::filesystem::path>` overload; requires `UVMap` with
+      `traits::WithChart`; emits one `newmtl materialN` / `map_Kd` entry per
+      path; groups faces by chart index of corner 0 with `usemtl materialN`
+      directives
+- [ ] **Task 2.6**: Implement `readOBJ(path, mesh)` — parses `v`, `vn`, `f`;
+      populates normals via `if constexpr`
+- [ ] **Task 2.7**: Implement `readOBJ(path, mesh, uvmap)` — also parses `vt`
+      and per-wedge UV indices from `f` lines; populates `uvmap`
+- [ ] **Task 2.8**: Implement `readOBJ(path, mesh, uvmap, texturePaths)` —
+      parses `.mtl` referenced by `mtllib` directive; extracts `map_Kd` paths
+      in material-declaration order into `texturePaths`; no-op if no `.mtl` or
+      no `map_Kd` entries
+- [ ] **Task 2.9**: Register `TestMeshIO` in `tests/CMakeLists.txt`; add
       `MeshIO.hpp` to installed headers in `CMakeLists.txt`
 
 ### Verification
 
 - [ ] `ctest` passes with no regressions
-- [ ] All OBJ round-trip tests pass
+- [ ] All OBJ round-trip tests pass (with and without texture paths)
 - [ ] Build succeeds in Debug and Release
 
 ---
 
 ## Phase 3: PLY IO
 
-Extend `MeshIO.hpp` with `readPLY` and `writePLY`.
+Extend `MeshIO.hpp` with `readPLY` and `writePLY`, including the
+seam-expansion adapter and `comment TextureFile` texture path handling.
 
 ### Tasks
 
@@ -91,28 +108,40 @@ Extend `MeshIO.hpp` with `readPLY` and `writePLY`.
       cover: mesh with no seams (no duplication), mesh with one seam edge
       (verify duplicate vertex count), verify face indices updated correctly,
       verify geometry identical to original at all vertex positions
-- [ ] **Task 3.2**: Implement `expandAtSeams(mesh, uvmap) -> std::pair<MeshT, std::vector<Vec<float,2>>>`
+- [ ] **Task 3.2**: Implement `expandAtSeams(mesh, uvmap) -> std::pair<MeshT, std::vector<Vec<T,2>>>`
       in `include/educelab/core/utils/MeshUtils.hpp`; walk each face corner,
       assign UV to vertex if unassigned, duplicate vertex if UV conflicts;
       return expanded mesh and flat per-vertex UV array
 - [ ] **Task 3.3**: Write round-trip tests for PLY in `TestMeshIO.cpp` —
-      cover: ASCII PLY positions only, positions + normals, positions + colors,
-      N-gon faces, binary-little-endian read, `writePLY` with `uvmap` (verify
-      vertex count expansion at seams), missing file error
+      cover: ASCII PLY positions only; positions + normals; positions + colors;
+      N-gon faces; binary-little-endian read; `writePLY` with `uvmap` (verify
+      vertex count expansion at seams); `writePLY` with `uvmap` + single
+      texture path (verify `comment TextureFile` in header and round-trip);
+      `writePLY` with `uvmap` + multiple texture paths (verify all
+      `comment TextureFile` lines written in order); `readPLY` parsing of
+      `comment TextureFile` into `texturePaths`; missing file error
 - [ ] **Task 3.4**: Implement `writePLY(path, mesh)` — ASCII PLY; writes
       header with `element vertex` / `element face`; conditionally includes
       `nx ny nz` properties (`if constexpr has_normal`) and `red green blue`
       properties (`if constexpr has_color`); writes data section
-- [ ] **Task 3.5**: Implement `writePLY(path, mesh, uvmap)` overload — calls
-      `expandAtSeams`, writes `s t` UV properties in vertex header and data
-- [ ] **Task 3.6**: Implement `readPLY(path, mesh)` — parses PLY header to
+- [ ] **Task 3.5**: Implement `writePLY(path, mesh, uvmap)` — calls
+      `expandAtSeams`, writes `s t` UV properties in vertex header and data;
+      no texture comment
+- [ ] **Task 3.6**: Implement `writePLY(path, mesh, uvmap, texturePaths)` —
+      extends Task 3.5; emits one `comment TextureFile <path>` line per entry
+      in `texturePaths` immediately after the `format` line in the PLY header
+      (MeshLab convention)
+- [ ] **Task 3.7**: Implement `readPLY(path, mesh)` — parses PLY header to
       determine present properties; reads ASCII and binary-little-endian data;
       populates normals/colors via `if constexpr`
+- [ ] **Task 3.8**: Implement `readPLY(path, mesh, texturePaths)` — extends
+      Task 3.7; parses `comment TextureFile` lines from PLY header into
+      `texturePaths` out-parameter (empty if none present)
 
 ### Verification
 
 - [ ] `ctest` passes with no regressions
-- [ ] All PLY round-trip tests pass
+- [ ] All PLY round-trip tests pass (with and without texture paths)
 - [ ] Build succeeds in Debug and Release
 
 ---
@@ -122,6 +151,7 @@ Extend `MeshIO.hpp` with `readPLY` and `writePLY`.
 - [ ] All acceptance criteria in `spec.md` met
 - [ ] All tests passing (`ctest`)
 - [ ] OBJ and PLY round-trips verified for all supported attribute combinations
+      including single-texture, multi-chart texture, and no-texture cases
 - [ ] Doxygen builds cleanly for all public IO functions
 - [ ] Ready for PR review
 

--- a/conductor/tracks/mesh-io_20260323/spec.md
+++ b/conductor/tracks/mesh-io_20260323/spec.md
@@ -8,86 +8,153 @@
 ## Summary
 
 Provide OBJ and PLY reader/writer functions for `Mesh`, supporting vertex
-normals, vertex colors, N-gon faces, and a single UV-mapped texture image per
-mesh. Readers/writers use `if constexpr` + the C++17 detection idiom to
-silently skip attributes the target mesh type does not carry.
+normals, vertex colors, N-gon faces, and per-chart texture image paths. Readers
+and writers use `if constexpr` + the C++17 detection idiom to silently skip
+attributes the target mesh type does not carry. Texture image loading is left
+to the caller; the IO layer manages only paths.
 
 ## Context
 
 EduceLab Core provides common types for EduceLab C++ projects. Downstream
 projects (volume-cartographer, registration-toolkit) currently use ITK/VTK for
-mesh IO; providing OBJ and PLY support in libcore is a prerequisite to
-replacing those dependencies. The mesh IO layer must compose cleanly with the
-`Mesh` composable traits system (`WithNormal`, `WithColor`) introduced in
-`mesh-redesign_20260320` and the `UVMap` companion type from `uv-map_20260323`.
+mesh IO and OpenCV/libtiff for texture loading; providing OBJ and PLY support
+in libcore is a prerequisite to replacing those dependencies. The mesh IO layer
+must compose cleanly with the `Mesh` composable traits system (`WithNormal`,
+`WithColor`) from `mesh-redesign_20260320` and the `UVMap` companion type
+from `uv-map_20260323`.
+
+Texture paths are passed separately from `UVMap` as a
+`std::vector<std::filesystem::path>` indexed by `traits::WithChart::chart`.
+Chart 0 is the implicit single-texture case; a `UVMap` without `WithChart`
+(all coordinates at the default `chart=0`) uses index 0. Image loading is
+always the caller's responsibility via `ImageIO`.
 
 ## User Story
 
-As an EduceLab developer, I want to read and write OBJ and PLY mesh files so
-that I can load and save meshes without depending on ITK or VTK.
+As an EduceLab developer, I want to read and write OBJ and PLY mesh files
+(including UV coordinates and texture image paths) so that I can load and save
+textured meshes without depending on ITK, VTK, or OpenCV.
 
 ## Acceptance Criteria
 
-- [ ] `readOBJ(path, mesh, uvmap)` and `writeOBJ(path, mesh, uvmap)` support:
-      vertex positions, N-gon faces, per-wedge UV coordinates (via `UVMap`),
-      vertex normals (if `WithNormal` trait present), vertex colors (if
-      `WithColor` trait present); unrecognized OBJ directives are silently
-      skipped
+- [ ] `readOBJ(path, mesh, uvmap, texturePaths)` and
+      `writeOBJ(path, mesh, uvmap, texturePaths)` support: vertex positions,
+      N-gon faces, per-wedge UV coordinates (via `UVMap`), vertex normals (if
+      `WithNormal` trait present), vertex colors (if `WithColor` trait present);
+      unrecognized OBJ directives are silently skipped
+- [ ] `writeOBJ` `texturePaths` overloads:
+      - `writeOBJ(path, mesh, uvmap)` — no texture; no `.mtl` emitted
+      - `writeOBJ(path, mesh, uvmap, texturePath)` — single
+        `std::filesystem::path`; emits a `.mtl` with one material (`map_Kd`)
+        regardless of `UVMap` traits; all faces reference that material
+      - `writeOBJ(path, mesh, uvmap, texturePaths)` — `std::vector<std::filesystem::path>`;
+        requires `UVMap` with `traits::WithChart`; emits one material per chart
+        in the `.mtl`, groups faces by chart using `usemtl` directives
+- [ ] `readOBJ` populates a `std::vector<std::filesystem::path>` out-parameter
+      with all `map_Kd` paths from the referenced `.mtl` (empty if no `.mtl`
+      or no `map_Kd` entries); order matches chart index (material 0 → index 0)
 - [ ] `readPLY(path, mesh)` and `writePLY(path, mesh)` support: vertex
       positions, N-gon faces, vertex normals (if `WithNormal` trait present),
       vertex colors (if `WithColor` trait present)
-- [ ] `writePLY(path, mesh, uvmap)` overload is supported via a seam-expansion
-      adapter: vertices at UV seam edges are duplicated so each vertex carries
-      a unique UV coordinate; the expanded mesh is written, not the original;
-      round-tripping through PLY with UVs does not recover the original vertex
-      count or seam topology (documented)
+- [ ] `writePLY(path, mesh, uvmap)` and `writePLY(path, mesh, uvmap, texturePaths)`
+      are supported via a seam-expansion adapter: vertices at UV seam edges are
+      duplicated so each vertex carries a unique UV coordinate; the expanded
+      mesh is written, not the original; round-tripping through PLY with UVs
+      does not recover the original vertex count or seam topology (documented)
+- [ ] `writePLY` with `texturePaths` writes one `comment TextureFile <path>`
+      line per path in the PLY header (MeshLab convention), in chart-index
+      order; `readPLY` parses these comments into a
+      `std::vector<std::filesystem::path>` out-parameter
 - [ ] Readers/writers are function templates over `MeshT`; absent traits are
       detected via `std::void_t` and handled with `if constexpr` — no runtime
       branching or virtual dispatch
-- [ ] `readOBJ` optionally loads the associated `.mtl` file and returns the
-      path to the first referenced texture image (if any); actual image loading
-      is left to the caller via `ImageIO`
-- [ ] All reader functions return a `bool` (or throw on error) and populate
-      the mesh in-place; error messages are reported via return value or
-      exception (consistent with existing `ImageIO` convention)
+- [ ] All reader functions return `bool` (or throw on error) and populate the
+      mesh in-place; error reporting is consistent with existing `ImageIO`
+      convention
 - [ ] Tests cover: round-trip write+read for OBJ and PLY, meshes with and
-      without normals/colors/UVs, N-gon faces, missing/malformed files
+      without normals/colors/UVs/texture paths, single-texture and multi-chart
+      texture paths, N-gon faces, missing/malformed files
 - [ ] All additions are C++17 compatible; IO headers live under `io/`
 
 ## Dependencies
 
 - `mesh-redesign_20260320` — composable traits (`WithNormal`, `WithColor`),
-  adjacency index, and face normal cache must be complete
-- `uv-map_20260323` — `UVMap` must be complete for OBJ UV read/write
-- `ImageIO.hpp` — existing; used by callers to load texture images returned
-  by `readOBJ`; not a new dependency
+  adjacency index, and face normal cache must be complete and merged
+- `uv-map_20260323` — `UVMap` (including `traits::WithChart`) must be complete
+  and merged
+- `ImageIO.hpp` — existing; used by callers to load texture images; not a new
+  dependency for this track
+- `<filesystem>` — C++17 standard; no new external dependency
 
 ## Out of Scope
 
-- Multiple UV channels / texture images per mesh (future feature)
-- Binary PLY write (ASCII PLY only to start)
+- Multiple UV channels per mesh (a single `UVMap` per mesh)
+- Binary PLY write (ASCII PLY only; binary-little-endian read is in scope)
 - STL read/write (future feature)
 - glTF / FBX / other formats
-- Texture image loading inside the mesh IO functions themselves (callers use
-  `ImageIO` directly)
+- Texture image loading inside IO functions (callers use `ImageIO`)
 - Mesh validation on read
+- Full MTL material support (only `map_Kd` diffuse texture path extracted)
 
 ## Technical Notes
 
-- Follow the existing `io/ImageIO.hpp` pattern for header location and
-  CMakeLists registration
-- OBJ MTL parsing need only extract the `map_Kd` (diffuse texture) path;
-  full material support is out of scope
-- PLY reader should handle both ASCII and binary-little-endian PLY files on
-  read; ASCII-only on write is acceptable for now
-- The detection idiom helpers (`has_normal<T>`, `has_color<T>`) introduced
-  in `mesh-redesign_20260320` should live in a shared internal header
-  (`types/detail/MeshTraits.hpp` or similar) reused by both `Mesh.hpp` and
-  the IO headers
-- The seam-expansion adapter (`expandAtSeams(mesh, uvmap) -> pair<Mesh, vector<Vec2f>>`)
-  belongs in a mesh utilities header (e.g. `utils/MeshUtils.hpp`), not in the
-  IO layer; `writePLY(path, mesh, uvmap)` calls it internally; it is also
-  independently useful for GPU upload and other per-vertex UV consumers
+### Texture Path Convention
+
+`texturePaths[i]` is the image for chart `i`. A `UVMap` without `WithChart`
+(all coordinates default to `chart=0`) uses `texturePaths[0]`. Callers
+building single-texture meshes from VC/RT do not need `WithChart` — they pass
+a single path via the `std::filesystem::path` overload or a one-element vector.
+
+### OBJ / MTL Multi-Texture Layout
+
+Single texture (one path):
+```
+# mesh.mtl
+newmtl material0
+map_Kd texture.png
+```
+All `f` lines are preceded by a single `usemtl material0`.
+
+Multi-texture (chart-indexed paths):
+```
+# mesh.mtl
+newmtl material0
+map_Kd chart0.png
+
+newmtl material1
+map_Kd chart1.png
+```
+`writeOBJ` groups faces by the chart index of their corner 0 vertex and emits
+`usemtl materialN` before each group. `readOBJ` maps material declaration order
+to chart index (first material → chart 0).
+
+Only `map_Kd` is read/written; all other MTL directives are ignored on read
+and not emitted on write.
+
+### PLY Texture Header Comments (MeshLab convention)
+
+```
+comment TextureFile chart0.png
+comment TextureFile chart1.png
+```
+
+One `comment TextureFile` line per chart, in chart-index order, in the PLY
+header immediately after the `ply` / `format` lines. This is the format
+written by MeshLab and readable by Blender, CloudCompare, and other tools.
+`readPLY` parses these comments into the `texturePaths` out-parameter.
+
+### Detection Idiom Infrastructure
+
+`has_normal<T>` and `has_color<T>` traits live in
+`include/educelab/core/types/detail/MeshTraits.hpp`, shared between `Mesh.hpp`
+and all IO headers.
+
+### Seam-Expansion Adapter
+
+`expandAtSeams(mesh, uvmap) -> std::pair<MeshT, std::vector<Vec<T,2>>>`
+lives in `include/educelab/core/utils/MeshUtils.hpp`. `writePLY` with a
+`uvmap` calls it internally. The returned flat per-vertex UV array is written
+as `s t` properties. This adapter is independently useful for GPU upload.
 
 ---
 

--- a/conductor/tracks/uv-map_20260323/metadata.json
+++ b/conductor/tracks/uv-map_20260323/metadata.json
@@ -2,9 +2,9 @@
   "id": "uv-map_20260323",
   "title": "UVMap",
   "type": "feature",
-  "status": "pending",
+  "status": "in_progress",
   "created": "2026-03-23T00:00:00Z",
-  "updated": "2026-03-23T00:00:00Z",
+  "updated": "2026-03-24T00:00:00Z",
   "phases": {
     "total": 1,
     "completed": 0

--- a/conductor/tracks/uv-map_20260323/metadata.json
+++ b/conductor/tracks/uv-map_20260323/metadata.json
@@ -2,15 +2,15 @@
   "id": "uv-map_20260323",
   "title": "UVMap",
   "type": "feature",
-  "status": "in_progress",
+  "status": "complete",
   "created": "2026-03-23T00:00:00Z",
   "updated": "2026-03-24T00:00:00Z",
   "phases": {
     "total": 1,
-    "completed": 0
+    "completed": 1
   },
   "tasks": {
     "total": 4,
-    "completed": 0
+    "completed": 4
   }
 }

--- a/conductor/tracks/uv-map_20260323/plan.md
+++ b/conductor/tracks/uv-map_20260323/plan.md
@@ -7,9 +7,11 @@
 
 ## Overview
 
-Single focused phase: port and generalize the `UVMap` from registration-toolkit
-into a standalone header-only class. No dependencies on other in-progress
-tracks.
+Single focused phase: implement `UVMap<T, Dims, Traits>` as a header-only class
+template with per-wedge UV/UVW storage. Uses `Vec<T,Dims>` from libcore; no
+OpenCV dependency. Two-level API (pool + per-wedge index) mirrors OBJ/PLY `vt`
+index structure. `Coordinate` inner struct mirrors `Mesh::Vertex` — inherits
+`Vec<T,Dims>` and `Traits` with full operator overloads to prevent slicing.
 
 ## Checkpoints
 
@@ -26,25 +28,71 @@ corresponding test in `tests/`.
 
 ### Tasks
 
-- [ ] **Task 1.1**: Review the `UVMap` implementation in registration-toolkit;
-      note any API surface, data structures, or edge cases to preserve or
-      generalize
-- [ ] **Task 1.2**: Write tests in `tests/src/TestUVMap.cpp` covering:
-      `insertUV`, `mapUV`, `uv`, `hasUV`, `numUVs`, unmapped wedge access,
-      face/corner indices that require growth of internal storage, copy and
-      move semantics
-- [ ] **Task 1.3**: Implement `UVMap` in `include/educelab/core/types/UVMap.hpp`;
-      internal storage: `std::vector<Vec<float,2>> uvs_` (pool) and
-      `std::vector<std::vector<std::size_t>> faceUVs_` (per-face per-corner
-      index); sentinel value `std::numeric_limits<std::size_t>::max()` for
-      unmapped wedges
-- [ ] **Task 1.4**: Register `TestUVMap` in `tests/CMakeLists.txt`
+- [x] **Task 1.1**: Write tests in `tests/src/TestUVMap.cpp` covering:
+      - `insert(Vec)` and `at` round-trip for a single coordinate
+      - variadic `insert(u, v)` round-trip
+      - `at` on a non-const map returns `Coordinate&`; mutating the returned
+        reference updates the pool entry (verify position and trait field)
+      - `at` on a const map returns `const Coordinate&`; implicit conversion
+        to `Vec<T,Dims>` works (verifies inheritance)
+      - `map` + `get` on a triangle face (corners 0, 1, 2)
+      - `map` + `get` on a quad face (4 corners)
+      - corners mapped out of order (e.g. corner 2 before corner 0)
+      - `has` returns false for unmapped corner, out-of-range face, and
+        out-of-range corner
+      - `get` throws `std::out_of_range` for unmapped wedge
+      - `get_coordinate` on a non-const map returns a mutable `Coordinate&`;
+        mutating it updates the pool entry
+      - `get_coordinate` throws for unmapped wedge
+      - `at` throws `std::out_of_range` for out-of-bounds pool index
+      - `map` auto-grows when face or corner index exceeds current storage
+      - two wedges sharing the same pool entry (verify `get` returns same index)
+      - `size` reflects pool count; `empty` true before any insert
+      - `reserve_uvs` and `reserve_faces` do not change logical state
+      - `clear` resets pool and wedge mapping; `empty` true after clear
+      - copy semantics: copied map is independent
+      - `Coordinate` arithmetic operators return `Coordinate` (not `Vec`) —
+        verify trait fields survive addition and scalar multiplication
+      - `UVMap<float, 2, WithChart>`: insert a `Coordinate` with `chart` set,
+        retrieve via `at` and verify `chart` field is preserved
+      - `UVMap<double, 3>` used for a UVW (3D) coordinate round-trip
+
+- [x] **Task 1.2**: Implement `UVMap<T, Dims, Traits>` in
+      `include/educelab/core/types/UVMap.hpp`:
+      - `DefaultUVTraits` empty struct and `WithChart` mixin above the class
+        definition
+      - Template signature:
+        `template <typename T = float, std::size_t Dims = 2, typename Traits = DefaultUVTraits, std::enable_if_t<std::is_arithmetic_v<T>, bool> = true>`
+      - `Coordinate` inner struct: inherits `Vec<T,Dims>` and `Traits`; default
+        constructor; variadic constructor forwarding to `Vec<T,Dims>`;
+        `using Vec<T,Dims>::operator=`; compound-assignment operators
+        (`+=`, `-=`, `*=`, `/=`) returning `Coordinate&`; friend binary
+        operators (`+`, `-`, `*`, `/`) returning `Coordinate` — identical
+        pattern to `Mesh::Vertex`
+      - Internal storage: `std::vector<Coordinate> uvs_` and
+        `std::vector<std::vector<std::optional<std::size_t>>> face_uvs_`
+      - `insert(const Coordinate&)` appends to `uvs_`, returns index
+      - `insert(const Vec<T,Dims>&)` constructs a default `Coordinate` from the
+        Vec and appends
+      - Variadic `insert(Args...)` with `static_assert(sizeof...(Args) == Dims)`,
+        constructs `Coordinate` from args
+      - `at(idx)` — two overloads: non-const delegates to `uvs_.at(idx)`,
+        const delegates to `std::as_const(uvs_).at(idx)`
+      - `map(face, corner, uvIdx)` resizes outer then inner vector, assigns
+      - `get(face, corner)` returns `face_uvs_[face][corner].value()`, throws
+        `std::out_of_range` if out of range or nullopt
+      - `get_coordinate(face, corner)` — two overloads: non-const returns
+        `at(get(face, corner))`, const returns `std::as_const(*this).at(...)`
+      - `has(face, corner)` returns false for any out-of-range or nullopt slot
+      - `size()`, `empty()`, `clear()`, `reserve_uvs()`, `reserve_faces()`
+
+- [x] **Task 1.3**: Register `TestUVMap` in `tests/CMakeLists.txt`
 
 ### Verification
 
-- [ ] `ctest` passes with no regressions
-- [ ] All `TestUVMap` tests pass
-- [ ] Build succeeds in Debug and Release
+- [x] `ctest` passes with no regressions
+- [x] All `TestUVMap` tests pass
+- [x] Build succeeds in Debug and Release
 
 ---
 

--- a/conductor/tracks/uv-map_20260323/plan.md
+++ b/conductor/tracks/uv-map_20260323/plan.md
@@ -3,7 +3,7 @@
 **Track ID:** uv-map_20260323
 **Spec:** [spec.md](./spec.md)
 **Created:** 2026-03-23
-**Status:** [ ] Not Started
+**Status:** [x] Complete
 
 ## Overview
 
@@ -98,8 +98,8 @@ corresponding test in `tests/`.
 
 ## Final Verification
 
-- [ ] All acceptance criteria in `spec.md` met
-- [ ] All tests passing (`ctest`)
+- [x] All acceptance criteria in `spec.md` met
+- [x] All tests passing (`ctest`)
 - [ ] Doxygen builds cleanly for `UVMap` public API
 - [ ] Ready for PR review
 

--- a/conductor/tracks/uv-map_20260323/spec.md
+++ b/conductor/tracks/uv-map_20260323/spec.md
@@ -7,43 +7,67 @@
 
 ## Summary
 
-Introduce a `UVMap` class providing per-wedge (per face-corner) UV coordinate
-storage as a companion to `Mesh`. Ported and generalized from the
-implementation in registration-toolkit.
+Introduce a `UVMap<T, Dims, Traits>` class template providing per-wedge
+(per face-corner) UV/UVW coordinate storage as a companion to `Mesh`.
+Generalized from the usage patterns in registration-toolkit, but redesigned as
+a header-only, OpenCV-free, N-gon-capable class template with a two-level API
+mirroring the OBJ/PLY index structure and an opt-in traits system for
+per-coordinate metadata.
 
 ## Context
 
 EduceLab Core provides common types for EduceLab C++ projects. UV coordinates
 must be stored per-wedge — not per-vertex — to correctly represent UV seams,
 where the same vertex position carries different UV coordinates in adjacent
-faces. `UVMap` is a standalone companion to `Mesh` (not embedded in it) so
-that meshes that do not require UV data carry no overhead.
+faces. `UVMap` is a standalone companion to `Mesh` (not embedded in it) so that
+meshes that do not require UV data carry no overhead.
+
+The `Dims` template parameter generalizes the class beyond 2D texture space:
+`UVMap<>` (defaulting to `float, 2`) is a standard UV map; `UVMap<float, 3>`
+is a UVW map for volumetric textures. `T` allows callers to choose float vs.
+double precision. `Traits` allows opt-in per-coordinate metadata via the same
+mixin pattern used by `Mesh::Vertex`.
 
 ## User Story
 
-As an EduceLab developer, I want a per-wedge UV coordinate store that
-accompanies a `Mesh` so that I can represent UV-mapped textures with correct
-seam handling when reading and writing mesh files.
+As an EduceLab developer, I want a per-wedge UV/UVW coordinate store that
+accompanies a `Mesh` so that I can represent UV-mapped textures and atlases
+with correct seam handling when reading and writing mesh files, regardless of
+coordinate dimensionality, and optionally attach per-coordinate metadata.
 
 ## Acceptance Criteria
 
-- [ ] `UVMap` stores a pool of `Vec<float, 2>` UV coordinates; coordinates
-      are inserted via `insertUV(u, v) -> std::size_t` and retrieved by index
-- [ ] Per-wedge mapping is set via `mapUV(face, corner, uvIdx)` and queried
-      via `uv(face, corner) -> Vec<float, 2>`; accessing an unmapped wedge
-      throws or returns a sentinel (documented)
-- [ ] `hasUV(face, corner) -> bool` allows callers to check before accessing
-- [ ] `numUVs() -> std::size_t` returns the size of the UV coordinate pool
-- [ ] `UVMap` is default-constructible and copyable/movable
-- [ ] A `UVMap` may be associated with a `Mesh` externally; there is no
-      ownership coupling between the two types
+- [ ] `UVMap<T, Dims, Traits>` stores a pool of `Coordinate` objects (see
+      Technical Notes); coordinates are inserted via
+      `insert(Coordinate) -> std::size_t`, a `Vec`-accepting overload
+      `insert(Vec<T,Dims>) -> std::size_t`, and a variadic overload
+      `insert(T u, T v, ...) -> std::size_t`; retrieved by index via
+      `at(std::size_t) -> const Coordinate&`, which throws `std::out_of_range`
+      for an out-of-bounds index
+- [ ] Per-wedge mapping is set via `map(face, corner, uvIdx)` (auto-grows
+      storage) and queried via `get(face, corner) -> std::size_t` (returns the
+      pool index); both `face` and `corner` are `std::size_t`
+- [ ] `get_coordinate(face, corner) -> const Coordinate&` is a convenience
+      wrapper equivalent to `at(get(face, corner))`
+- [ ] `get` and `get_coordinate` throw `std::out_of_range` for any unmapped
+      wedge; `has(face, corner) -> bool` is the sanctioned pre-check
+- [ ] `size() -> std::size_t` returns the UV coordinate pool size; `empty() ->
+      bool` returns whether the pool is empty
+- [ ] `reserve_uvs(std::size_t)` pre-allocates the UV pool; `reserve_faces(
+      std::size_t)` pre-allocates the outer face entries in `face_uvs_`
+- [ ] `clear()` resets both the UV pool and the per-wedge mapping to empty
+- [ ] `UVMap<T, Dims, Traits>` is default-constructible and copyable/movable
+- [ ] Template parameters default to `T = float`, `Dims = 2`,
+      `Traits = DefaultUVTraits`; `UVMap<>` is a standard 2D float UV map
+- [ ] A `WithChart` mixin is provided: `struct WithChart { std::size_t
+      chart{0}; }`; composable as `UVMap<float, 2, WithChart>`
 - [ ] All additions are C++17 compatible and header-only
 - [ ] Tests achieve ≥80% coverage of all public methods
 
 ## Dependencies
 
 - `Vec.hpp` (no change required)
-- No dependency on `mesh-redesign_20260323` — `UVMap` is independent of `Mesh`
+- No dependency on `mesh-redesign_20260320` — `UVMap` is independent of `Mesh`
 
 ## Out of Scope
 
@@ -51,17 +75,132 @@ seam handling when reading and writing mesh files.
 - Multiple UV channels per mesh (future feature)
 - UV coordinate validation (e.g. range checks on [0,1])
 - Embedding `UVMap` inside `Mesh`
+- Origin-flip conversion (TopLeft/BottomLeft) — callers handle coordinate
+  system transformation at IO boundaries
+- Per-map metadata such as texture dimensions (caller's responsibility)
+- Convenience type aliases
 
 ## Technical Notes
 
-- Internal storage: `std::vector<Vec<float,2>> uvs_` (UV pool) and
-  `std::vector<std::vector<std::size_t>> faceUVs_` (per-face, per-corner UV
-  index); `faceUVs_[f][c]` holds the index into `uvs_` for face `f` corner `c`
-- `mapUV` must grow `faceUVs_` if `face` is out of range, and grow
-  `faceUVs_[face]` if `corner` is out of range; unset slots are a sentinel
-  value (e.g. `std::numeric_limits<std::size_t>::max()`)
-- This mirrors the OBJ format's separate `vt` index space exactly,
-  simplifying the mesh IO track's OBJ reader/writer
+### `Coordinate` Inner Struct
+
+`UVMap<T, Dims, Traits>` defines an inner struct `Coordinate` that inherits
+from both `Vec<T,Dims>` and `Traits`, mirroring the design of `Mesh::Vertex`:
+
+```cpp
+struct Coordinate : public Vec<T, Dims>, public Traits {
+    Coordinate() = default;
+
+    template <typename... Args>
+    explicit Coordinate(Args... args) : Vec<T, Dims>{args...} {}
+
+    using Vec<T, Dims>::operator=;
+
+    // operator+=, -=, *=, /= returning Coordinate& (not Vec&)
+    // operator+, -, *, / as friend functions returning Coordinate
+    // (same set as Mesh::Vertex — prevents slicing of Traits fields)
+};
+```
+
+The arithmetic overloads are necessary to prevent slicing: `Vec`'s operators
+return `Vec` / `Vec&`, which would discard any `Traits` fields on copy or
+assignment. `Coordinate`'s overloads shadow them and return `Coordinate` /
+`Coordinate&`.
+
+### Traits
+
+```cpp
+// Default: no extra per-coordinate data
+struct DefaultUVTraits {};
+
+// Opt-in chart index
+struct WithChart { std::size_t chart{0}; };
+```
+
+Callers compose traits via multiple inheritance if needed:
+```cpp
+struct MyTraits : WithChart { /* ... */ };
+using MyUVMap = UVMap<float, 2, MyTraits>;
+```
+
+### API Summary
+
+```cpp
+template <typename T = float, std::size_t Dims = 2,
+          typename Traits = DefaultUVTraits,
+          std::enable_if_t<std::is_arithmetic_v<T>, bool> = true>
+class UVMap {
+public:
+    struct Coordinate : public Vec<T,Dims>, public Traits { /* ... */ };
+
+    // UV pool
+    auto insert(const Coordinate&) -> std::size_t;
+    auto insert(const Vec<T,Dims>&) -> std::size_t;
+    template <typename... Args>
+    auto insert(Args...) -> std::size_t;              // e.g. insert(0.5f, 0.25f)
+    auto at(std::size_t) -> Coordinate&;              // throws out_of_range
+    auto at(std::size_t) const -> const Coordinate&;  // throws out_of_range
+
+    // Per-wedge mapping
+    void map(std::size_t face, std::size_t corner, std::size_t uvIdx);
+    auto get(std::size_t face, std::size_t corner) -> std::size_t;
+    auto get_coordinate(std::size_t face, std::size_t corner) -> Coordinate&;
+    auto get_coordinate(std::size_t face, std::size_t corner) const
+        -> const Coordinate&;
+    auto has(std::size_t face, std::size_t corner) -> bool;
+
+    // Container
+    auto size() -> std::size_t;
+    auto empty() -> bool;
+    void reserve_uvs(std::size_t);
+    void reserve_faces(std::size_t);
+    void clear();
+};
+```
+
+### Internal Storage
+
+- `std::vector<Coordinate> uvs_` — the UV coordinate pool
+- `std::vector<std::vector<std::optional<std::size_t>>> face_uvs_` — per-face,
+  per-corner UV pool index; `face_uvs_[f][c]` is `std::nullopt` if unmapped
+
+### Growth Behavior of `map`
+
+`map(face, corner, idx)` performs:
+1. `face_uvs_.resize(face + 1, {})` — grows outer vector if needed
+2. `face_uvs_[face].resize(corner + 1, std::nullopt)` — grows inner vector if needed
+3. `face_uvs_[face][corner] = idx`
+
+Corners may be mapped in any order; gaps remain `std::nullopt` until filled.
+`face_uvs_[face].size()` reflects the highest corner index mapped so far, not
+the face's canonical corner count — `has()` is the correct query.
+
+### Two-Level Design
+
+The pool + per-wedge index structure mirrors the OBJ/PLY file formats' separate
+`vt` index space: multiple wedges can reference the same pool entry (no
+duplication), and the same vertex can map to different UV coordinates in
+different faces (seam handling). The mesh-io track uses `insert`/`map` directly
+when reading files (indices are explicit). Programmatic construction uses vertex
+indices as deduplication keys:
+
+```cpp
+std::vector<std::size_t> vert_to_uv(mesh.num_vertices());
+for (std::size_t vi = 0; vi < mesh.num_vertices(); ++vi)
+    vert_to_uv[vi] = uvmap.insert(compute_uv(vi));
+for (std::size_t fi = 0; fi < mesh.num_faces(); ++fi) {
+    const auto& f = mesh.face(fi);
+    for (std::size_t ci = 0; ci < f.size(); ++ci)
+        uvmap.map(fi, ci, vert_to_uv[f[ci]]);
+}
+```
+
+### Design Contrast With rt::UVMap
+
+rt::UVMap stores UV coordinates per-vertex, breaking down at UV seams.
+`UVMap<T,Dims,Traits>` uses per-wedge indexing, which maps directly to OBJ/PLY.
+rt::UVMap is hardcoded to triangles, requires OpenCV, and is not templated.
+`UVMap<T,Dims,Traits>` removes all three constraints.
 
 ---
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -21,3 +21,6 @@ target_link_libraries(educelab_core_MatExample educelab::core)
 
 add_executable(educelab_core_CachingExample CachingExample.cpp)
 target_link_libraries(educelab_core_CachingExample educelab::core)
+
+add_executable(educelab_core_MeshExample MeshExample.cpp)
+target_link_libraries(educelab_core_MeshExample educelab::core)

--- a/examples/MeshExample.cpp
+++ b/examples/MeshExample.cpp
@@ -1,0 +1,117 @@
+#include <iostream>
+
+#include "educelab/core/types/Mesh.hpp"
+#include "educelab/core/types/UVMap.hpp"
+
+using namespace educelab;
+
+auto main() -> int
+{
+    //--------------------------------------------------------------------------
+    // Basic mesh: positions only
+    //--------------------------------------------------------------------------
+    // Default Mesh<float, 3> — no extra vertex traits
+    Mesh<float, 3> mesh;
+
+    // Insert vertices (returns index)
+    auto v0 = mesh.insert_vertex(0.F, 0.F, 0.F);
+    auto v1 = mesh.insert_vertex(1.F, 0.F, 0.F);
+    auto v2 = mesh.insert_vertex(1.F, 1.F, 0.F);
+    auto v3 = mesh.insert_vertex(0.F, 1.F, 0.F);
+
+    // Insert a quad face (N-gon faces are supported)
+    auto f0 = mesh.insert_face(v0, v1, v2, v3);
+
+    std::cout << "Vertex 0: " << mesh.vertex(v0) << "\n";  // [0, 0, 0]
+    std::cout << "Vertex 2: " << mesh.vertex(v2) << "\n";  // [1, 1, 0]
+
+    // Adjacency: which faces contain vertex 1?
+    for (auto fi : mesh.vertex_faces(v1)) {
+        std::cout << "Vertex 1 in face " << fi << "\n";  // face 0
+    }
+
+    // Face normal (computed on demand, cached)
+    std::cout << "Face 0 normal: " << mesh.face_normal(f0) << "\n";  // [0, 0, 1]
+
+    //--------------------------------------------------------------------------
+    // Mesh with normals and colors (composable traits)
+    //--------------------------------------------------------------------------
+    struct MyTraits : traits::WithNormal<float, 3>, traits::WithColor {};
+    using RichMesh = Mesh<float, 3, MyTraits>;
+
+    RichMesh rich;
+    auto rv0 = rich.insert_vertex(0.F, 0.F, 0.F);
+    auto rv1 = rich.insert_vertex(1.F, 0.F, 0.F);
+    auto rv2 = rich.insert_vertex(0.5F, 1.F, 0.F);
+    rich.insert_face(rv0, rv1, rv2);
+
+    rich.vertex(rv0).normal = Vec3f{0.F, 0.F, 1.F};
+    rich.vertex(rv0).color  = Color::U8C3{255, 0, 0};
+
+    auto& vert = rich.vertex(rv0);
+    auto rgb = vert.color.value<Color::U8C3>();
+    std::cout << "Normal: " << vert.normal.value() << "\n";  // [0, 0, 1]
+    std::cout << "Color:  [" << int(rgb[0]) << ", " << int(rgb[1]) << ", "
+              << int(rgb[2]) << "]\n";  // [255, 0, 0]
+
+    //--------------------------------------------------------------------------
+    // UVMap: per-wedge UV coordinates
+    //--------------------------------------------------------------------------
+    // UVMap<float, 2> — default 2D UV, no chart index
+    UVMap<float, 2> uvmap;
+
+    // Insert UV coordinates into the pool (returns pool index)
+    auto uv0 = uvmap.insert(0.0F, 0.0F);
+    auto uv1 = uvmap.insert(1.0F, 0.0F);
+    auto uv2 = uvmap.insert(1.0F, 1.0F);
+    auto uv3 = uvmap.insert(0.0F, 1.0F);
+
+    std::cout << "UV pool size: " << uvmap.size() << "\n";  // 4
+
+    // Assign pool entries to per-face corners (face index, corner index, UV index)
+    uvmap.map(f0, 0, uv0);
+    uvmap.map(f0, 1, uv1);
+    uvmap.map(f0, 2, uv2);
+    uvmap.map(f0, 3, uv3);
+
+    // Look up the coordinate for face 0, corner 2
+    const auto& coord = uvmap.get_coordinate(f0, 2);
+    std::cout << "UV at (face=0, corner=2): [" << coord[0] << ", " << coord[1]
+              << "]\n";  // [1, 1]
+
+    // Seam support: the same vertex can have different UVs in adjacent faces
+    auto v4 = mesh.insert_vertex(0.5F, 0.5F, 0.F);
+    auto f1 = mesh.insert_face(v0, v4, v3);
+    auto uv_seam_a = uvmap.insert(0.5F, 0.5F);
+    auto uv_seam_b = uvmap.insert(0.5F, 0.6F);  // same vertex, different UV
+    uvmap.map(f0, 0, uv_seam_a);
+    uvmap.map(f1, 0, uv_seam_b);
+    std::cout << "Seam UV on face 0: " << uvmap.get_coordinate(f0, 0)[0] << "\n";  // 0.5
+    std::cout << "Seam UV on face 1: " << uvmap.get_coordinate(f1, 0)[1] << "\n";  // 0.6
+
+    //--------------------------------------------------------------------------
+    // UVMap with chart index (multi-texture atlas)
+    //--------------------------------------------------------------------------
+    using ChartedUVMap = UVMap<float, 2, traits::WithChart>;
+    ChartedUVMap charted;
+
+    // Coordinate on chart 0
+    ChartedUVMap::Coordinate c0(0.25F, 0.25F);
+    c0.chart = 0;
+    auto ci0 = charted.insert(c0);
+
+    // Coordinate on chart 1
+    ChartedUVMap::Coordinate c1(0.75F, 0.75F);
+    c1.chart = 1;
+    auto ci1 = charted.insert(c1);
+
+    charted.map(0, 0, ci0);
+    charted.map(0, 1, ci1);
+
+    std::cout << "UV for corner 0: [" << charted.get_coordinate(0, 0)[0]
+              << ", " << charted.get_coordinate(0, 0)[1]
+              << "] on chart " << charted.get_coordinate(0, 0).chart << "\n";  // chart 0
+    std::cout << "UV for corner 1: [" << charted.get_coordinate(0, 1)[0]
+              << ", " << charted.get_coordinate(0, 1)[1]
+              << "] on chart " << charted.get_coordinate(0, 1).chart << "\n";  // chart 1
+}

--- a/include/educelab/core.hpp
+++ b/include/educelab/core.hpp
@@ -9,6 +9,7 @@
 #include "educelab/core/types/Mat.hpp"
 #include "educelab/core/types/Mesh.hpp"
 #include "educelab/core/types/Signals.hpp"
+#include "educelab/core/types/UVMap.hpp"
 #include "educelab/core/types/Uuid.hpp"
 #include "educelab/core/types/Vec.hpp"
 

--- a/include/educelab/core/types/UVMap.hpp
+++ b/include/educelab/core/types/UVMap.hpp
@@ -1,0 +1,313 @@
+#pragma once
+
+/** @file */
+
+#include <optional>
+#include <stdexcept>
+#include <type_traits>
+#include <vector>
+
+#include "educelab/core/types/Vec.hpp"
+
+namespace educelab
+{
+
+/** @brief Default (empty) per-coordinate traits for UVMap */
+struct DefaultUVTraits {
+};
+
+/**
+ * @brief Opt-in chart-index mixin for UVMap coordinates
+ *
+ * Compose into a custom traits struct (or use directly) to attach a UV atlas
+ * chart index to each coordinate:
+ * @code
+ * using MyUVMap = UVMap<float, 2, WithChart>;
+ * @endcode
+ */
+struct WithChart {
+    /** @brief Atlas chart index */
+    std::size_t chart{0};
+};
+
+/**
+ * @brief Per-wedge UV/UVW coordinate store
+ *
+ * Provides a two-level API mirroring the OBJ/PLY @c vt index structure: a
+ * flat pool of @c Coordinate objects plus a per-face, per-corner index into
+ * that pool. Multiple wedges may reference the same pool entry (no
+ * duplication), and the same vertex can map to different UV coordinates in
+ * adjacent faces (UV seam support).
+ *
+ * @tparam T      Element type (default: @c float)
+ * @tparam Dims   Coordinate dimensionality (default: 2 for UV; use 3 for UVW)
+ * @tparam Traits Optional per-coordinate metadata mixin (default:
+ *                @ref DefaultUVTraits)
+ */
+template <
+    typename T = float,
+    std::size_t Dims = 2,
+    typename Traits = DefaultUVTraits,
+    std::enable_if_t<std::is_arithmetic_v<T>, bool> = true>
+class UVMap
+{
+public:
+    /**
+     * @brief Per-coordinate type inheriting @c Vec<T,Dims> and @c Traits
+     *
+     * Arithmetic operators are defined on @c Coordinate (not inherited from
+     * @c Vec) so that both return @c Coordinate / @c Coordinate& rather than
+     * @c Vec / @c Vec&, preserving any @c Traits fields across arithmetic.
+     */
+    struct Coordinate : public Vec<T, Dims>, public Traits {
+        /** @brief Default constructor */
+        Coordinate() = default;
+
+        /**
+         * @brief Construct with element values
+         *
+         * The number of arguments must match @c Dims.
+         */
+        template <typename... Args>
+        explicit Coordinate(Args... args) : Vec<T, Dims>{args...}
+        {
+        }
+
+        /** Inherit value-assignment operator from Vec */
+        using Vec<T, Dims>::operator=;
+
+        /** @brief Addition-assignment operator */
+        template <class Vector>
+        auto operator+=(const Vector& rhs) -> Coordinate&
+        {
+            Vec<T, Dims>::operator+=(rhs);
+            return *this;
+        }
+
+        /** @brief Subtraction-assignment operator */
+        template <class Vector>
+        auto operator-=(const Vector& rhs) -> Coordinate&
+        {
+            Vec<T, Dims>::operator-=(rhs);
+            return *this;
+        }
+
+        /** @brief Scalar multiplication-assignment operator */
+        template <class Scalar>
+        auto operator*=(const Scalar& rhs) -> Coordinate&
+        {
+            Vec<T, Dims>::operator*=(rhs);
+            return *this;
+        }
+
+        /** @brief Scalar division-assignment operator */
+        template <class Scalar>
+        auto operator/=(const Scalar& rhs) -> Coordinate&
+        {
+            Vec<T, Dims>::operator/=(rhs);
+            return *this;
+        }
+
+        /** @brief Addition operator */
+        template <class Vector>
+        friend auto operator+(Coordinate lhs, const Vector& rhs) -> Coordinate
+        {
+            lhs += rhs;
+            return lhs;
+        }
+
+        /** @brief Subtraction operator */
+        template <class Vector>
+        friend auto operator-(Coordinate lhs, const Vector& rhs) -> Coordinate
+        {
+            lhs -= rhs;
+            return lhs;
+        }
+
+        /** @brief Scalar multiplication operator */
+        template <class Scalar>
+        friend auto operator*(Coordinate lhs, const Scalar& rhs) -> Coordinate
+        {
+            lhs *= rhs;
+            return lhs;
+        }
+
+        /** @brief Scalar division operator */
+        template <class Scalar>
+        friend auto operator/(Coordinate lhs, const Scalar& rhs) -> Coordinate
+        {
+            lhs /= rhs;
+            return lhs;
+        }
+    };
+
+    //--------------------------------------------------------------------------
+    // UV coordinate pool
+    //--------------------------------------------------------------------------
+
+    /**
+     * @brief Insert a coordinate into the pool
+     *
+     * @return Index of the inserted coordinate
+     */
+    auto insert(const Coordinate& c) -> std::size_t
+    {
+        const auto idx = uvs_.size();
+        uvs_.push_back(c);
+        return idx;
+    }
+
+    /**
+     * @brief Insert a @c Vec<T,Dims> into the pool (constructs a default
+     *        @c Coordinate with the Vec values)
+     *
+     * @return Index of the inserted coordinate
+     */
+    auto insert(const Vec<T, Dims>& v) -> std::size_t
+    {
+        const auto idx = uvs_.size();
+        Coordinate c;
+        static_cast<Vec<T, Dims>&>(c) = v;
+        uvs_.push_back(c);
+        return idx;
+    }
+
+    /**
+     * @brief Insert coordinate values directly (variadic)
+     *
+     * The number of arguments must equal @c Dims.
+     *
+     * @return Index of the inserted coordinate
+     */
+    template <typename... Args>
+    auto insert(Args... args) -> std::size_t
+    {
+        static_assert(
+            sizeof...(Args) == Dims, "insert: argument count must equal Dims");
+        const auto idx = uvs_.size();
+        uvs_.emplace_back(args...);
+        return idx;
+    }
+
+    /**
+     * @brief Bounds-checked access to a pool coordinate (mutable)
+     *
+     * @throws std::out_of_range if @p idx >= pool size
+     */
+    auto at(std::size_t idx) -> Coordinate& { return uvs_.at(idx); }
+
+    /**
+     * @brief Bounds-checked access to a pool coordinate (const)
+     *
+     * @throws std::out_of_range if @p idx >= pool size
+     */
+    auto at(std::size_t idx) const -> const Coordinate&
+    {
+        return std::as_const(uvs_).at(idx);
+    }
+
+    //--------------------------------------------------------------------------
+    // Per-wedge mapping
+    //--------------------------------------------------------------------------
+
+    /**
+     * @brief Assign pool index @p uvIdx to wedge (face @p face, corner
+     *        @p corner)
+     *
+     * Auto-grows storage if @p face or @p corner exceed current bounds.
+     */
+    void map(std::size_t face, std::size_t corner, std::size_t uvIdx)
+    {
+        if (face >= face_uvs_.size()) {
+            face_uvs_.resize(face + 1);
+        }
+        if (corner >= face_uvs_[face].size()) {
+            face_uvs_[face].resize(corner + 1, std::nullopt);
+        }
+        face_uvs_[face][corner] = uvIdx;
+    }
+
+    /**
+     * @brief Return the pool index for wedge (face, corner)
+     *
+     * @throws std::out_of_range if the wedge is out of range or unmapped
+     */
+    auto get(std::size_t face, std::size_t corner) -> std::size_t
+    {
+        if (face >= face_uvs_.size() || corner >= face_uvs_[face].size() ||
+            !face_uvs_[face][corner].has_value()) {
+            throw std::out_of_range("UVMap::get: wedge is unmapped");
+        }
+        return *face_uvs_[face][corner];
+    }
+
+    /**
+     * @brief Convenience: return the coordinate for wedge (face, corner)
+     *        (mutable)
+     *
+     * Equivalent to @c at(get(face, corner)).
+     *
+     * @throws std::out_of_range if the wedge is unmapped
+     */
+    auto get_coordinate(std::size_t face, std::size_t corner) -> Coordinate&
+    {
+        return at(get(face, corner));
+    }
+
+    /**
+     * @brief Convenience: return the coordinate for wedge (face, corner)
+     *        (const)
+     *
+     * @throws std::out_of_range if the wedge is unmapped
+     */
+    auto get_coordinate(std::size_t face, std::size_t corner) const
+        -> const Coordinate&
+    {
+        return std::as_const(*this).at(
+            const_cast<UVMap*>(this)->get(face, corner));
+    }
+
+    /**
+     * @brief Return whether wedge (face, corner) has been mapped
+     *
+     * Returns @c false for any out-of-range index or unmapped slot.
+     */
+    auto has(std::size_t face, std::size_t corner) const -> bool
+    {
+        if (face >= face_uvs_.size() || corner >= face_uvs_[face].size()) {
+            return false;
+        }
+        return face_uvs_[face][corner].has_value();
+    }
+
+    //--------------------------------------------------------------------------
+    // Container
+    //--------------------------------------------------------------------------
+
+    /** @brief Number of coordinates in the pool */
+    auto size() const -> std::size_t { return uvs_.size(); }
+
+    /** @brief Whether the coordinate pool is empty */
+    auto empty() const -> bool { return uvs_.empty(); }
+
+    /** @brief Pre-allocate pool capacity */
+    void reserve_uvs(std::size_t n) { uvs_.reserve(n); }
+
+    /** @brief Pre-allocate outer face entries */
+    void reserve_faces(std::size_t n) { face_uvs_.reserve(n); }
+
+    /** @brief Reset pool and per-wedge mapping to empty */
+    void clear()
+    {
+        uvs_.clear();
+        face_uvs_.clear();
+    }
+
+private:
+    /** UV coordinate pool */
+    std::vector<Coordinate> uvs_;
+    /** Per-face, per-corner UV pool index; nullopt if unmapped */
+    std::vector<std::vector<std::optional<std::size_t>>> face_uvs_;
+};
+
+}  // namespace educelab

--- a/include/educelab/core/types/UVMap.hpp
+++ b/include/educelab/core/types/UVMap.hpp
@@ -12,6 +12,9 @@
 namespace educelab
 {
 
+namespace traits
+{
+
 /** @brief Default (empty) per-coordinate traits for UVMap */
 struct DefaultUVTraits {
 };
@@ -22,13 +25,15 @@ struct DefaultUVTraits {
  * Compose into a custom traits struct (or use directly) to attach a UV atlas
  * chart index to each coordinate:
  * @code
- * using MyUVMap = UVMap<float, 2, WithChart>;
+ * using MyUVMap = UVMap<float, 2, traits::WithChart>;
  * @endcode
  */
 struct WithChart {
     /** @brief Atlas chart index */
     std::size_t chart{0};
 };
+
+}  // namespace traits
 
 /**
  * @brief Per-wedge UV/UVW coordinate store
@@ -39,16 +44,16 @@ struct WithChart {
  * duplication), and the same vertex can map to different UV coordinates in
  * adjacent faces (UV seam support).
  *
- * @tparam T      Element type (default: @c float)
+ * @tparam T      Floating-point element type (default: @c float)
  * @tparam Dims   Coordinate dimensionality (default: 2 for UV; use 3 for UVW)
  * @tparam Traits Optional per-coordinate metadata mixin (default:
- *                @ref DefaultUVTraits)
+ *                @ref traits::DefaultUVTraits)
  */
 template <
     typename T = float,
     std::size_t Dims = 2,
-    typename Traits = DefaultUVTraits,
-    std::enable_if_t<std::is_arithmetic_v<T>, bool> = true>
+    typename Traits = traits::DefaultUVTraits,
+    std::enable_if_t<std::is_floating_point_v<T>, bool> = true>
 class UVMap
 {
 public:
@@ -150,10 +155,22 @@ public:
      *
      * @return Index of the inserted coordinate
      */
-    auto insert(const Coordinate& c) -> std::size_t
+    [[nodiscard]] auto insert(const Coordinate& c) -> std::size_t
     {
         const auto idx = uvs_.size();
         uvs_.push_back(c);
+        return idx;
+    }
+
+    /**
+     * @brief Insert a coordinate into the pool (move)
+     *
+     * @return Index of the inserted coordinate
+     */
+    [[nodiscard]] auto insert(Coordinate&& c) -> std::size_t
+    {
+        const auto idx = uvs_.size();
+        uvs_.push_back(std::move(c));
         return idx;
     }
 
@@ -163,12 +180,12 @@ public:
      *
      * @return Index of the inserted coordinate
      */
-    auto insert(const Vec<T, Dims>& v) -> std::size_t
+    [[nodiscard]] auto insert(const Vec<T, Dims>& v) -> std::size_t
     {
         const auto idx = uvs_.size();
         Coordinate c;
         static_cast<Vec<T, Dims>&>(c) = v;
-        uvs_.push_back(c);
+        uvs_.push_back(std::move(c));
         return idx;
     }
 
@@ -180,7 +197,7 @@ public:
      * @return Index of the inserted coordinate
      */
     template <typename... Args>
-    auto insert(Args... args) -> std::size_t
+    [[nodiscard]] auto insert(Args... args) -> std::size_t
     {
         static_assert(
             sizeof...(Args) == Dims, "insert: argument count must equal Dims");
@@ -194,14 +211,17 @@ public:
      *
      * @throws std::out_of_range if @p idx >= pool size
      */
-    auto at(std::size_t idx) -> Coordinate& { return uvs_.at(idx); }
+    [[nodiscard]] auto at(std::size_t idx) -> Coordinate&
+    {
+        return uvs_.at(idx);
+    }
 
     /**
      * @brief Bounds-checked access to a pool coordinate (const)
      *
      * @throws std::out_of_range if @p idx >= pool size
      */
-    auto at(std::size_t idx) const -> const Coordinate&
+    [[nodiscard]] auto at(std::size_t idx) const -> const Coordinate&
     {
         return std::as_const(uvs_).at(idx);
     }
@@ -215,6 +235,10 @@ public:
      *        @p corner)
      *
      * Auto-grows storage if @p face or @p corner exceed current bounds.
+     * Overwrites any existing mapping for the wedge.
+     *
+     * @pre @p face and @p corner must not equal @c std::numeric_limits<std::size_t>::max()
+     * @pre @p uvIdx < size()
      */
     void map(std::size_t face, std::size_t corner, std::size_t uvIdx)
     {
@@ -232,7 +256,8 @@ public:
      *
      * @throws std::out_of_range if the wedge is out of range or unmapped
      */
-    auto get(std::size_t face, std::size_t corner) -> std::size_t
+    [[nodiscard]] auto get(std::size_t face, std::size_t corner) const
+        -> std::size_t
     {
         if (face >= face_uvs_.size() || corner >= face_uvs_[face].size() ||
             !face_uvs_[face][corner].has_value()) {
@@ -249,7 +274,8 @@ public:
      *
      * @throws std::out_of_range if the wedge is unmapped
      */
-    auto get_coordinate(std::size_t face, std::size_t corner) -> Coordinate&
+    [[nodiscard]] auto get_coordinate(std::size_t face, std::size_t corner)
+        -> Coordinate&
     {
         return at(get(face, corner));
     }
@@ -260,11 +286,10 @@ public:
      *
      * @throws std::out_of_range if the wedge is unmapped
      */
-    auto get_coordinate(std::size_t face, std::size_t corner) const
-        -> const Coordinate&
+    [[nodiscard]] auto get_coordinate(
+        std::size_t face, std::size_t corner) const -> const Coordinate&
     {
-        return std::as_const(*this).at(
-            const_cast<UVMap*>(this)->get(face, corner));
+        return at(get(face, corner));
     }
 
     /**
@@ -272,7 +297,7 @@ public:
      *
      * Returns @c false for any out-of-range index or unmapped slot.
      */
-    auto has(std::size_t face, std::size_t corner) const -> bool
+    [[nodiscard]] auto has(std::size_t face, std::size_t corner) const -> bool
     {
         if (face >= face_uvs_.size() || corner >= face_uvs_[face].size()) {
             return false;
@@ -285,10 +310,13 @@ public:
     //--------------------------------------------------------------------------
 
     /** @brief Number of coordinates in the pool */
-    auto size() const -> std::size_t { return uvs_.size(); }
+    [[nodiscard]] auto size() const noexcept -> std::size_t
+    {
+        return uvs_.size();
+    }
 
     /** @brief Whether the coordinate pool is empty */
-    auto empty() const -> bool { return uvs_.empty(); }
+    [[nodiscard]] auto empty() const noexcept -> bool { return uvs_.empty(); }
 
     /** @brief Pre-allocate pool capacity */
     void reserve_uvs(std::size_t n) { uvs_.reserve(n); }
@@ -297,7 +325,7 @@ public:
     void reserve_faces(std::size_t n) { face_uvs_.reserve(n); }
 
     /** @brief Reset pool and per-wedge mapping to empty */
-    void clear()
+    void clear() noexcept
     {
         uvs_.clear();
         face_uvs_.clear();
@@ -306,7 +334,14 @@ public:
 private:
     /** UV coordinate pool */
     std::vector<Coordinate> uvs_;
-    /** Per-face, per-corner UV pool index; nullopt if unmapped */
+    /**
+     * Per-face, per-corner UV pool index; nullopt if unmapped.
+     *
+     * @todo The vector-of-vectors layout causes one heap allocation per face
+     *       and pointer-chasing on every access. For large meshes a flat layout
+     *       with an offset table would improve cache locality. A fixed-stride
+     *       triangle-only variant is the right solution for real-time use cases.
+     */
     std::vector<std::vector<std::optional<std::size_t>>> face_uvs_;
 };
 

--- a/include/educelab/core/types/UVMap.hpp
+++ b/include/educelab/core/types/UVMap.hpp
@@ -5,6 +5,7 @@
 #include <optional>
 #include <stdexcept>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 #include "educelab/core/types/Vec.hpp"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ set(tests
     src/TestSignals.cpp
     src/TestString.cpp
     src/TestUuid.cpp
+    src/TestUVMap.cpp
     src/TestVec.cpp
     src/TestVersion.cpp
 )

--- a/tests/src/TestUVMap.cpp
+++ b/tests/src/TestUVMap.cpp
@@ -49,7 +49,7 @@ TEST(UVMap, InsertVecRoundTrip)
 TEST(UVMap, AtNonConstReturnsMutableRef)
 {
     UVMap2f m;
-    m.insert(0.0f, 0.0f);
+    (void)m.insert(0.0f, 0.0f);
     Coord2f& ref = m.at(0);
     ref[0] = 0.8f;
     ref[1] = 0.2f;
@@ -60,7 +60,7 @@ TEST(UVMap, AtNonConstReturnsMutableRef)
 TEST(UVMap, AtConstReturnsConstRef)
 {
     UVMap2f m;
-    m.insert(0.4f, 0.6f);
+    (void)m.insert(0.4f, 0.6f);
     const UVMap2f& cm = m;
     const Coord2f& ref = cm.at(0);
     // Implicit conversion to Vec verifies inheritance
@@ -72,9 +72,9 @@ TEST(UVMap, AtConstReturnsConstRef)
 TEST(UVMap, AtThrowsOutOfRange)
 {
     UVMap2f m;
-    EXPECT_THROW(m.at(0), std::out_of_range);
-    m.insert(0.0f, 0.0f);
-    EXPECT_THROW(m.at(1), std::out_of_range);
+    EXPECT_THROW((void)m.at(0), std::out_of_range);
+    (void)m.insert(0.0f, 0.0f);
+    EXPECT_THROW((void)m.at(1), std::out_of_range);
 }
 
 //------------------------------------------------------------------------------
@@ -140,13 +140,31 @@ TEST(UVMap, CornersOutOfOrder)
 }
 
 //------------------------------------------------------------------------------
+// Overwrite: remapping an already-mapped wedge updates the index
+//------------------------------------------------------------------------------
+
+TEST(UVMap, RemapWedgeUpdatesIndex)
+{
+    UVMap2f m;
+    const auto idx0 = m.insert(0.1f, 0.2f);
+    const auto idx1 = m.insert(0.8f, 0.9f);
+
+    m.map(0, 0, idx0);
+    EXPECT_EQ(m.get(0, 0), idx0);
+
+    // Remap the same wedge to a different pool entry
+    m.map(0, 0, idx1);
+    EXPECT_EQ(m.get(0, 0), idx1);
+}
+
+//------------------------------------------------------------------------------
 // has()
 //------------------------------------------------------------------------------
 
 TEST(UVMap, HasReturnsFalseForUnmappedCorner)
 {
     UVMap2f m;
-    m.insert(0.0f, 0.0f);
+    (void)m.insert(0.0f, 0.0f);
     m.map(0, 0, 0);
     EXPECT_FALSE(m.has(0, 1));
 }
@@ -160,7 +178,7 @@ TEST(UVMap, HasReturnsFalseForOutOfRangeFace)
 TEST(UVMap, HasReturnsFalseForOutOfRangeCorner)
 {
     UVMap2f m;
-    m.insert(0.0f, 0.0f);
+    (void)m.insert(0.0f, 0.0f);
     m.map(0, 0, 0);
     EXPECT_FALSE(m.has(0, 99));
 }
@@ -168,7 +186,7 @@ TEST(UVMap, HasReturnsFalseForOutOfRangeCorner)
 TEST(UVMap, HasReturnsTrueForMappedWedge)
 {
     UVMap2f m;
-    m.insert(0.0f, 0.0f);
+    (void)m.insert(0.0f, 0.0f);
     m.map(0, 0, 0);
     EXPECT_TRUE(m.has(0, 0));
 }
@@ -180,15 +198,15 @@ TEST(UVMap, HasReturnsTrueForMappedWedge)
 TEST(UVMap, GetThrowsForUnmappedCorner)
 {
     UVMap2f m;
-    m.insert(0.0f, 0.0f);
+    (void)m.insert(0.0f, 0.0f);
     m.map(0, 0, 0);
-    EXPECT_THROW(m.get(0, 1), std::out_of_range);
+    EXPECT_THROW((void)m.get(0, 1), std::out_of_range);
 }
 
 TEST(UVMap, GetThrowsForOutOfRangeFace)
 {
     UVMap2f m;
-    EXPECT_THROW(m.get(99, 0), std::out_of_range);
+    EXPECT_THROW((void)m.get(99, 0), std::out_of_range);
 }
 
 //------------------------------------------------------------------------------
@@ -198,7 +216,7 @@ TEST(UVMap, GetThrowsForOutOfRangeFace)
 TEST(UVMap, GetCoordinateNonConstReturnsMutableRef)
 {
     UVMap2f m;
-    m.insert(0.1f, 0.2f);
+    (void)m.insert(0.1f, 0.2f);
     m.map(0, 0, 0);
 
     Coord2f& ref = m.get_coordinate(0, 0);
@@ -209,7 +227,7 @@ TEST(UVMap, GetCoordinateNonConstReturnsMutableRef)
 TEST(UVMap, GetCoordinateConstReturnsConstRef)
 {
     UVMap2f m;
-    m.insert(0.3f, 0.4f);
+    (void)m.insert(0.3f, 0.4f);
     m.map(0, 0, 0);
 
     const UVMap2f& cm = m;
@@ -221,8 +239,23 @@ TEST(UVMap, GetCoordinateConstReturnsConstRef)
 TEST(UVMap, GetCoordinateThrowsForUnmappedWedge)
 {
     UVMap2f m;
-    m.insert(0.0f, 0.0f);
-    EXPECT_THROW(m.get_coordinate(0, 0), std::out_of_range);
+    (void)m.insert(0.0f, 0.0f);
+    EXPECT_THROW((void)m.get_coordinate(0, 0), std::out_of_range);
+}
+
+// Const get_coordinate preserves trait fields when Traits is non-empty
+TEST(UVMap, GetCoordinateConstPreservesWithChartTrait)
+{
+    UVMap<float, 2, traits::WithChart> m;
+    UVMap<float, 2, traits::WithChart>::Coordinate c;
+    c[0] = 0.5f;
+    c[1] = 0.5f;
+    c.chart = 11;
+    (void)m.insert(c);
+    m.map(0, 0, 0);
+
+    const auto& cm = m;
+    EXPECT_EQ(cm.get_coordinate(0, 0).chart, 11u);
 }
 
 //------------------------------------------------------------------------------
@@ -264,11 +297,11 @@ TEST(UVMap, SizeAndEmpty)
     EXPECT_TRUE(m.empty());
     EXPECT_EQ(m.size(), 0u);
 
-    m.insert(0.0f, 0.0f);
+    (void)m.insert(0.0f, 0.0f);
     EXPECT_FALSE(m.empty());
     EXPECT_EQ(m.size(), 1u);
 
-    m.insert(1.0f, 1.0f);
+    (void)m.insert(1.0f, 1.0f);
     EXPECT_EQ(m.size(), 2u);
 }
 
@@ -287,13 +320,13 @@ TEST(UVMap, ReserveDoesNotChangeLogicalState)
 }
 
 //------------------------------------------------------------------------------
-// clear()
+// clear(): resets state and allows re-use
 //------------------------------------------------------------------------------
 
 TEST(UVMap, ClearResetsPoolAndMapping)
 {
     UVMap2f m;
-    m.insert(0.0f, 0.0f);
+    (void)m.insert(0.0f, 0.0f);
     m.map(0, 0, 0);
 
     m.clear();
@@ -301,6 +334,13 @@ TEST(UVMap, ClearResetsPoolAndMapping)
     EXPECT_TRUE(m.empty());
     EXPECT_EQ(m.size(), 0u);
     EXPECT_FALSE(m.has(0, 0));
+
+    // Map is fully functional after clear
+    const auto idx = m.insert(0.7f, 0.3f);
+    m.map(0, 0, idx);
+    EXPECT_TRUE(m.has(0, 0));
+    EXPECT_EQ(m.get(0, 0), idx);
+    EXPECT_EQ(m.at(idx)[0], 0.7f);
 }
 
 //------------------------------------------------------------------------------
@@ -310,7 +350,7 @@ TEST(UVMap, ClearResetsPoolAndMapping)
 TEST(UVMap, CopyIsIndependent)
 {
     UVMap2f m;
-    m.insert(0.1f, 0.2f);
+    (void)m.insert(0.1f, 0.2f);
     m.map(0, 0, 0);
 
     UVMap2f copy = m;
@@ -324,13 +364,59 @@ TEST(UVMap, CopyIsIndependent)
 }
 
 //------------------------------------------------------------------------------
+// Move semantics
+//------------------------------------------------------------------------------
+
+TEST(UVMap, MoveConstruction)
+{
+    UVMap2f m;
+    (void)m.insert(0.1f, 0.2f);
+    m.map(0, 0, 0);
+
+    UVMap2f moved = std::move(m);
+
+    EXPECT_EQ(moved.size(), 1u);
+    EXPECT_TRUE(moved.has(0, 0));
+    EXPECT_EQ(moved.at(0)[0], 0.1f);
+}
+
+TEST(UVMap, MoveAssignment)
+{
+    UVMap2f m;
+    (void)m.insert(0.3f, 0.4f);
+    m.map(0, 0, 0);
+
+    UVMap2f moved;
+    moved = std::move(m);
+
+    EXPECT_EQ(moved.size(), 1u);
+    EXPECT_TRUE(moved.has(0, 0));
+    EXPECT_EQ(moved.at(0)[0], 0.3f);
+}
+
+//------------------------------------------------------------------------------
+// Default template arguments: UVMap<> is a 2D float UV map
+//------------------------------------------------------------------------------
+
+TEST(UVMap, DefaultTemplateArguments)
+{
+    UVMap<> m;
+    const auto idx = m.insert(0.5f, 0.25f);
+    EXPECT_EQ(m.at(idx)[0], 0.5f);
+    EXPECT_EQ(m.at(idx)[1], 0.25f);
+    m.map(0, 0, idx);
+    EXPECT_EQ(m.get(0, 0), idx);
+}
+
+//------------------------------------------------------------------------------
 // Coordinate arithmetic operators return Coordinate (not Vec)
 //------------------------------------------------------------------------------
 
-TEST(UVMap, CoordinateArithmeticPreservesType)
+TEST(UVMap, CoordinateArithmeticAddPreservesLhsChart)
 {
-    // Verify that operator+ returns Coordinate, not Vec, so trait fields survive
-    using Map = UVMap<float, 2, WithChart>;
+    // operator+ takes lhs by value (copying a's traits); result inherits a's
+    // chart field. b's chart is not propagated.
+    using Map = UVMap<float, 2, traits::WithChart>;
     using Coord = Map::Coordinate;
 
     Coord a;
@@ -341,20 +427,70 @@ TEST(UVMap, CoordinateArithmeticPreservesType)
     Coord b;
     b[0] = 0.4f;
     b[1] = 0.6f;
-    b.chart = 7;  // should be ignored by operator+ (only Vec data added)
+    b.chart = 7;
 
     Coord sum = a + b;
     EXPECT_NEAR(sum[0], 0.5f, 1e-6f);
     EXPECT_NEAR(sum[1], 0.8f, 1e-6f);
+    EXPECT_EQ(sum.chart, 3u);  // lhs chart is preserved in result
+}
+
+TEST(UVMap, CoordinateArithmeticMulPreservesLhsChart)
+{
+    using Map = UVMap<float, 2, traits::WithChart>;
+    using Coord = Map::Coordinate;
+
+    Coord a;
+    a[0] = 0.1f;
+    a[1] = 0.2f;
+    a.chart = 3;
 
     Coord scaled = a * 2.0f;
     EXPECT_NEAR(scaled[0], 0.2f, 1e-6f);
     EXPECT_NEAR(scaled[1], 0.4f, 1e-6f);
+    EXPECT_EQ(scaled.chart, 3u);
+}
+
+TEST(UVMap, CoordinateArithmeticSubPreservesLhsChart)
+{
+    using Map = UVMap<float, 2, traits::WithChart>;
+    using Coord = Map::Coordinate;
+
+    Coord a;
+    a[0] = 0.9f;
+    a[1] = 0.8f;
+    a.chart = 5;
+
+    Coord b;
+    b[0] = 0.4f;
+    b[1] = 0.3f;
+    b.chart = 99;
+
+    Coord diff = a - b;
+    EXPECT_NEAR(diff[0], 0.5f, 1e-6f);
+    EXPECT_NEAR(diff[1], 0.5f, 1e-6f);
+    EXPECT_EQ(diff.chart, 5u);
+}
+
+TEST(UVMap, CoordinateArithmeticDivPreservesLhsChart)
+{
+    using Map = UVMap<float, 2, traits::WithChart>;
+    using Coord = Map::Coordinate;
+
+    Coord a;
+    a[0] = 0.8f;
+    a[1] = 0.4f;
+    a.chart = 2;
+
+    Coord divided = a / 2.0f;
+    EXPECT_NEAR(divided[0], 0.4f, 1e-6f);
+    EXPECT_NEAR(divided[1], 0.2f, 1e-6f);
+    EXPECT_EQ(divided.chart, 2u);
 }
 
 TEST(UVMap, CompoundAssignmentReturnsCoordsRef)
 {
-    using Map = UVMap<float, 2, WithChart>;
+    using Map = UVMap<float, 2, traits::WithChart>;
     using Coord = Map::Coordinate;
 
     Coord a;
@@ -379,8 +515,8 @@ TEST(UVMap, CompoundAssignmentReturnsCoordsRef)
 
 TEST(UVMap, WithChartTraitPreservedByAt)
 {
-    UVMap<float, 2, WithChart> m;
-    UVMap<float, 2, WithChart>::Coordinate c;
+    UVMap<float, 2, traits::WithChart> m;
+    UVMap<float, 2, traits::WithChart>::Coordinate c;
     c[0] = 0.5f;
     c[1] = 0.5f;
     c.chart = 7;

--- a/tests/src/TestUVMap.cpp
+++ b/tests/src/TestUVMap.cpp
@@ -1,0 +1,402 @@
+#include <gtest/gtest.h>
+
+#include "educelab/core/types/UVMap.hpp"
+
+using namespace educelab;
+
+// Convenience aliases used throughout
+using UVMap2f = UVMap<float, 2>;
+using Coord2f = UVMap2f::Coordinate;
+
+//------------------------------------------------------------------------------
+// Coordinate construction and round-trip via insert/at
+//------------------------------------------------------------------------------
+
+TEST(UVMap, InsertCoordinateAndAtRoundTrip)
+{
+    UVMap2f m;
+    Coord2f c;
+    c[0] = 0.5f;
+    c[1] = 0.25f;
+    const auto idx = m.insert(c);
+    EXPECT_EQ(m.at(idx)[0], 0.5f);
+    EXPECT_EQ(m.at(idx)[1], 0.25f);
+}
+
+TEST(UVMap, InsertVariadicRoundTrip)
+{
+    UVMap2f m;
+    const auto idx = m.insert(0.1f, 0.9f);
+    EXPECT_EQ(m.at(idx)[0], 0.1f);
+    EXPECT_EQ(m.at(idx)[1], 0.9f);
+}
+
+TEST(UVMap, InsertVecRoundTrip)
+{
+    UVMap2f m;
+    Vec<float, 2> v;
+    v[0] = 0.3f;
+    v[1] = 0.7f;
+    const auto idx = m.insert(v);
+    EXPECT_EQ(m.at(idx)[0], 0.3f);
+    EXPECT_EQ(m.at(idx)[1], 0.7f);
+}
+
+//------------------------------------------------------------------------------
+// Mutable and const at()
+//------------------------------------------------------------------------------
+
+TEST(UVMap, AtNonConstReturnsMutableRef)
+{
+    UVMap2f m;
+    m.insert(0.0f, 0.0f);
+    Coord2f& ref = m.at(0);
+    ref[0] = 0.8f;
+    ref[1] = 0.2f;
+    EXPECT_EQ(m.at(0)[0], 0.8f);
+    EXPECT_EQ(m.at(0)[1], 0.2f);
+}
+
+TEST(UVMap, AtConstReturnsConstRef)
+{
+    UVMap2f m;
+    m.insert(0.4f, 0.6f);
+    const UVMap2f& cm = m;
+    const Coord2f& ref = cm.at(0);
+    // Implicit conversion to Vec verifies inheritance
+    Vec<float, 2> v = ref;
+    EXPECT_EQ(v[0], 0.4f);
+    EXPECT_EQ(v[1], 0.6f);
+}
+
+TEST(UVMap, AtThrowsOutOfRange)
+{
+    UVMap2f m;
+    EXPECT_THROW(m.at(0), std::out_of_range);
+    m.insert(0.0f, 0.0f);
+    EXPECT_THROW(m.at(1), std::out_of_range);
+}
+
+//------------------------------------------------------------------------------
+// map / get on a triangle (3 corners)
+//------------------------------------------------------------------------------
+
+TEST(UVMap, MapAndGetTriangle)
+{
+    UVMap2f m;
+    const auto uv0 = m.insert(0.0f, 0.0f);
+    const auto uv1 = m.insert(1.0f, 0.0f);
+    const auto uv2 = m.insert(0.0f, 1.0f);
+
+    m.map(0, 0, uv0);
+    m.map(0, 1, uv1);
+    m.map(0, 2, uv2);
+
+    EXPECT_EQ(m.get(0, 0), uv0);
+    EXPECT_EQ(m.get(0, 1), uv1);
+    EXPECT_EQ(m.get(0, 2), uv2);
+}
+
+//------------------------------------------------------------------------------
+// map / get on a quad (4 corners)
+//------------------------------------------------------------------------------
+
+TEST(UVMap, MapAndGetQuad)
+{
+    UVMap2f m;
+    const auto uv0 = m.insert(0.0f, 0.0f);
+    const auto uv1 = m.insert(1.0f, 0.0f);
+    const auto uv2 = m.insert(1.0f, 1.0f);
+    const auto uv3 = m.insert(0.0f, 1.0f);
+
+    m.map(0, 0, uv0);
+    m.map(0, 1, uv1);
+    m.map(0, 2, uv2);
+    m.map(0, 3, uv3);
+
+    EXPECT_EQ(m.get(0, 0), uv0);
+    EXPECT_EQ(m.get(0, 1), uv1);
+    EXPECT_EQ(m.get(0, 2), uv2);
+    EXPECT_EQ(m.get(0, 3), uv3);
+}
+
+//------------------------------------------------------------------------------
+// Corners mapped out of order
+//------------------------------------------------------------------------------
+
+TEST(UVMap, CornersOutOfOrder)
+{
+    UVMap2f m;
+    const auto uv0 = m.insert(0.0f, 0.0f);
+    const auto uv2 = m.insert(0.5f, 0.5f);
+
+    m.map(0, 2, uv2);
+    m.map(0, 0, uv0);
+
+    EXPECT_EQ(m.get(0, 0), uv0);
+    EXPECT_EQ(m.get(0, 2), uv2);
+    // corner 1 was never mapped
+    EXPECT_FALSE(m.has(0, 1));
+}
+
+//------------------------------------------------------------------------------
+// has()
+//------------------------------------------------------------------------------
+
+TEST(UVMap, HasReturnsFalseForUnmappedCorner)
+{
+    UVMap2f m;
+    m.insert(0.0f, 0.0f);
+    m.map(0, 0, 0);
+    EXPECT_FALSE(m.has(0, 1));
+}
+
+TEST(UVMap, HasReturnsFalseForOutOfRangeFace)
+{
+    UVMap2f m;
+    EXPECT_FALSE(m.has(5, 0));
+}
+
+TEST(UVMap, HasReturnsFalseForOutOfRangeCorner)
+{
+    UVMap2f m;
+    m.insert(0.0f, 0.0f);
+    m.map(0, 0, 0);
+    EXPECT_FALSE(m.has(0, 99));
+}
+
+TEST(UVMap, HasReturnsTrueForMappedWedge)
+{
+    UVMap2f m;
+    m.insert(0.0f, 0.0f);
+    m.map(0, 0, 0);
+    EXPECT_TRUE(m.has(0, 0));
+}
+
+//------------------------------------------------------------------------------
+// get() throws for unmapped wedge
+//------------------------------------------------------------------------------
+
+TEST(UVMap, GetThrowsForUnmappedCorner)
+{
+    UVMap2f m;
+    m.insert(0.0f, 0.0f);
+    m.map(0, 0, 0);
+    EXPECT_THROW(m.get(0, 1), std::out_of_range);
+}
+
+TEST(UVMap, GetThrowsForOutOfRangeFace)
+{
+    UVMap2f m;
+    EXPECT_THROW(m.get(99, 0), std::out_of_range);
+}
+
+//------------------------------------------------------------------------------
+// get_coordinate
+//------------------------------------------------------------------------------
+
+TEST(UVMap, GetCoordinateNonConstReturnsMutableRef)
+{
+    UVMap2f m;
+    m.insert(0.1f, 0.2f);
+    m.map(0, 0, 0);
+
+    Coord2f& ref = m.get_coordinate(0, 0);
+    ref[0] = 0.9f;
+    EXPECT_EQ(m.at(0)[0], 0.9f);
+}
+
+TEST(UVMap, GetCoordinateConstReturnsConstRef)
+{
+    UVMap2f m;
+    m.insert(0.3f, 0.4f);
+    m.map(0, 0, 0);
+
+    const UVMap2f& cm = m;
+    const Coord2f& ref = cm.get_coordinate(0, 0);
+    EXPECT_EQ(ref[0], 0.3f);
+    EXPECT_EQ(ref[1], 0.4f);
+}
+
+TEST(UVMap, GetCoordinateThrowsForUnmappedWedge)
+{
+    UVMap2f m;
+    m.insert(0.0f, 0.0f);
+    EXPECT_THROW(m.get_coordinate(0, 0), std::out_of_range);
+}
+
+//------------------------------------------------------------------------------
+// Auto-grow: map beyond current storage
+//------------------------------------------------------------------------------
+
+TEST(UVMap, MapAutoGrowsFaceAndCorner)
+{
+    UVMap2f m;
+    const auto idx = m.insert(0.5f, 0.5f);
+    // face index 5, corner index 3 — well beyond initial empty storage
+    m.map(5, 3, idx);
+    EXPECT_TRUE(m.has(5, 3));
+    EXPECT_EQ(m.get(5, 3), idx);
+}
+
+//------------------------------------------------------------------------------
+// Two wedges sharing the same pool entry
+//------------------------------------------------------------------------------
+
+TEST(UVMap, TwoWedgesSharePoolEntry)
+{
+    UVMap2f m;
+    const auto sharedIdx = m.insert(0.5f, 0.5f);
+    m.map(0, 0, sharedIdx);
+    m.map(1, 2, sharedIdx);
+
+    EXPECT_EQ(m.get(0, 0), sharedIdx);
+    EXPECT_EQ(m.get(1, 2), sharedIdx);
+}
+
+//------------------------------------------------------------------------------
+// size() and empty()
+//------------------------------------------------------------------------------
+
+TEST(UVMap, SizeAndEmpty)
+{
+    UVMap2f m;
+    EXPECT_TRUE(m.empty());
+    EXPECT_EQ(m.size(), 0u);
+
+    m.insert(0.0f, 0.0f);
+    EXPECT_FALSE(m.empty());
+    EXPECT_EQ(m.size(), 1u);
+
+    m.insert(1.0f, 1.0f);
+    EXPECT_EQ(m.size(), 2u);
+}
+
+//------------------------------------------------------------------------------
+// reserve_uvs and reserve_faces do not change logical state
+//------------------------------------------------------------------------------
+
+TEST(UVMap, ReserveDoesNotChangeLogicalState)
+{
+    UVMap2f m;
+    m.reserve_uvs(100);
+    m.reserve_faces(50);
+    EXPECT_TRUE(m.empty());
+    EXPECT_EQ(m.size(), 0u);
+    EXPECT_FALSE(m.has(0, 0));
+}
+
+//------------------------------------------------------------------------------
+// clear()
+//------------------------------------------------------------------------------
+
+TEST(UVMap, ClearResetsPoolAndMapping)
+{
+    UVMap2f m;
+    m.insert(0.0f, 0.0f);
+    m.map(0, 0, 0);
+
+    m.clear();
+
+    EXPECT_TRUE(m.empty());
+    EXPECT_EQ(m.size(), 0u);
+    EXPECT_FALSE(m.has(0, 0));
+}
+
+//------------------------------------------------------------------------------
+// Copy semantics: copied map is independent
+//------------------------------------------------------------------------------
+
+TEST(UVMap, CopyIsIndependent)
+{
+    UVMap2f m;
+    m.insert(0.1f, 0.2f);
+    m.map(0, 0, 0);
+
+    UVMap2f copy = m;
+    copy.at(0)[0] = 0.9f;
+    m.map(1, 0, 0);
+
+    // Original pool entry unchanged
+    EXPECT_EQ(m.at(0)[0], 0.1f);
+    // Copy does not see original's new wedge mapping
+    EXPECT_FALSE(copy.has(1, 0));
+}
+
+//------------------------------------------------------------------------------
+// Coordinate arithmetic operators return Coordinate (not Vec)
+//------------------------------------------------------------------------------
+
+TEST(UVMap, CoordinateArithmeticPreservesType)
+{
+    // Verify that operator+ returns Coordinate, not Vec, so trait fields survive
+    using Map = UVMap<float, 2, WithChart>;
+    using Coord = Map::Coordinate;
+
+    Coord a;
+    a[0] = 0.1f;
+    a[1] = 0.2f;
+    a.chart = 3;
+
+    Coord b;
+    b[0] = 0.4f;
+    b[1] = 0.6f;
+    b.chart = 7;  // should be ignored by operator+ (only Vec data added)
+
+    Coord sum = a + b;
+    EXPECT_NEAR(sum[0], 0.5f, 1e-6f);
+    EXPECT_NEAR(sum[1], 0.8f, 1e-6f);
+
+    Coord scaled = a * 2.0f;
+    EXPECT_NEAR(scaled[0], 0.2f, 1e-6f);
+    EXPECT_NEAR(scaled[1], 0.4f, 1e-6f);
+}
+
+TEST(UVMap, CompoundAssignmentReturnsCoordsRef)
+{
+    using Map = UVMap<float, 2, WithChart>;
+    using Coord = Map::Coordinate;
+
+    Coord a;
+    a[0] = 0.5f;
+    a[1] = 0.5f;
+    a.chart = 42;
+
+    Coord b;
+    b[0] = 0.1f;
+    b[1] = 0.1f;
+
+    Coord& ref = (a += b);
+    // ref must alias a
+    ref.chart = 99;
+    EXPECT_EQ(a.chart, 99u);
+    EXPECT_NEAR(a[0], 0.6f, 1e-6f);
+}
+
+//------------------------------------------------------------------------------
+// WithChart trait: insert preserves chart field
+//------------------------------------------------------------------------------
+
+TEST(UVMap, WithChartTraitPreservedByAt)
+{
+    UVMap<float, 2, WithChart> m;
+    UVMap<float, 2, WithChart>::Coordinate c;
+    c[0] = 0.5f;
+    c[1] = 0.5f;
+    c.chart = 7;
+    const auto idx = m.insert(c);
+    EXPECT_EQ(m.at(idx).chart, 7u);
+}
+
+//------------------------------------------------------------------------------
+// UVMap<double, 3> for UVW coordinates
+//------------------------------------------------------------------------------
+
+TEST(UVMap, UVWDoubleRoundTrip)
+{
+    UVMap<double, 3> m;
+    const auto idx = m.insert(0.1, 0.2, 0.3);
+    EXPECT_DOUBLE_EQ(m.at(idx)[0], 0.1);
+    EXPECT_DOUBLE_EQ(m.at(idx)[1], 0.2);
+    EXPECT_DOUBLE_EQ(m.at(idx)[2], 0.3);
+}


### PR DESCRIPTION
Closes #13

## What changed

- **`include/educelab/core/types/UVMap.hpp`** — new header-only `UVMap<T, Dims, Traits>` type: per-wedge UV/UVW coordinate store with a flat pool + per-face/per-corner index, full arithmetic operators on `Coordinate`, and `traits::DefaultUVTraits` / `traits::WithChart` opt-in mixins
- **`tests/src/TestUVMap.cpp`** — 35 unit tests covering the full public API
- **`include/educelab/core.hpp`** — `UVMap.hpp` added to umbrella include
- **`CMakeLists.txt`** — `UVMap.hpp` registered in `public_hdrs` (installed with the library)
- **`examples/MeshExample.cpp`** — new example demonstrating `Mesh` and `UVMap` usage
- **`README.md`** — added Mesh and UVMap usage sections; updated header-only dependency list
- **`conductor/`** — `uv-map_20260323` track marked complete; `mesh-io_20260323` spec and plan updated with texture path handling design decisions (unblocked by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)