### PR TITLE
fix(cmake): correct install dirs and use GNUInstallDirs

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -20,8 +20,28 @@ jobs:
 
       - name: Build libcore
         run: |
-          cmake -S . -B build $EXTRA_CMAKE_FLAGS
+          cmake -S . -B build $EXTRA_CMAKE_FLAGS -DCMAKE_INSTALL_PREFIX="$PWD/install"
           cmake --build build/ -j 4
 
       - name: Run tests
         run: ctest -V --test-dir build/
+
+      - name: Install libcore
+        run: cmake --install build/
+
+      - name: Test find_package from a consumer project
+        run: |
+          mkdir -p consumer
+          cat > consumer/CMakeLists.txt <<'EOF'
+          cmake_minimum_required(VERSION 3.15)
+          project(consumer CXX)
+          find_package(EduceLabCore REQUIRED)
+          add_executable(consumer main.cpp)
+          target_link_libraries(consumer PRIVATE educelab::core)
+          EOF
+          cat > consumer/main.cpp <<'EOF'
+          #include "educelab/core/io/MeshIO.hpp"
+          int main() { return 0; }
+          EOF
+          cmake -S consumer -B consumer/build -DCMAKE_PREFIX_PATH="$PWD/install"
+          cmake --build consumer/build -j 4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 # Modules
 include(FetchContent)
 include(CMakeDependentOption)
+include(GNUInstallDirs)
 
 # Get Git hash
 include(GetGitRevisionDescription)
@@ -68,17 +69,19 @@ target_compile_features(core PUBLIC cxx_std_17)
 if(EDUCE_CORE_CHARCONV_DEFS)
     target_compile_definitions(core PUBLIC ${EDUCE_CORE_CHARCONV_DEFS})
 endif()
-set_target_properties(core
-    PROPERTIES
-        PUBLIC_HEADER "${public_hdrs}"
-)
 install(
     TARGETS core
     EXPORT EduceLabCoreTargets
-    ARCHIVE DESTINATION "lib"
-    LIBRARY DESTINATION "lib"
-    INCLUDES DESTINATION "include/educelab/core"
-    PUBLIC_HEADER DESTINATION "include/educelab/core"
+    ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+    INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+)
+# Install headers preserving their directory structure under include/educelab/core
+install(
+    DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/"
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+    FILES_MATCHING PATTERN "*.hpp"
 )
 
 # Docs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ set(public_hdrs
     include/educelab/core/types/Uuid.hpp
     include/educelab/core/types/Vec.hpp
     include/educelab/core/utils/Caching.hpp
+    include/educelab/core/utils/Flags.hpp
     include/educelab/core/utils/MeshUtils.hpp
     include/educelab/core/utils/Filesystem.hpp
     include/educelab/core/utils/Iteration.hpp

--- a/cmake/InstallProject.cmake
+++ b/cmake/InstallProject.cmake
@@ -6,16 +6,20 @@ write_basic_package_version_file(
 )
 configure_file(cmake/EduceLabCoreConfig.cmake.in EduceLabCoreConfig.cmake @ONLY)
 
+# Package config must live in a directory matching find_package(EduceLabCore)'s
+# search glob (<prefix>/<libdir>/cmake/EduceLabCore*), otherwise it is not found.
+set(EduceLabCore_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/EduceLabCore")
+
 install(
     EXPORT EduceLabCoreTargets
     FILE EduceLabCoreTargets.cmake
     NAMESPACE educelab::
-    DESTINATION lib/cmake/EduceLab
+    DESTINATION "${EduceLabCore_INSTALL_CMAKEDIR}"
 )
 
 install(
     FILES
         "${CMAKE_CURRENT_BINARY_DIR}/EduceLabCoreConfig.cmake"
         "${CMAKE_CURRENT_BINARY_DIR}/EduceLabCoreConfigVersion.cmake"
-    DESTINATION lib/cmake/EduceLab
+    DESTINATION "${EduceLabCore_INSTALL_CMAKEDIR}"
 )


### PR DESCRIPTION
## Summary
- `find_package(EduceLabCore)` failed because the package config was installed to `lib/cmake/EduceLab`, which does not match CMake's search glob `<prefix>/<libdir>/cmake/EduceLabCore*`. Config files now install to `lib/cmake/EduceLabCore`.
- Replaced hardcoded `lib`/`include` install destinations with **GNUInstallDirs** (`CMAKE_INSTALL_LIBDIR`/`INCLUDEDIR`/`BINDIR`).
- Dropped the `PUBLIC_HEADER` install rule, which flattened every header into a single directory and broke nested includes such as `"educelab/core/io/MeshIO.hpp"`. Headers are now installed via a directory copy that preserves the `io/`, `types/`, and `utils/` subdirectories.

## Testing
- Configured, built, and installed to a temp prefix — headers land under `include/educelab/core/{io,types,utils}/...` and config under `lib/cmake/EduceLabCore/`.
- Verified a downstream project using `find_package(EduceLabCore REQUIRED)` + `target_link_libraries(... educelab::core)` configures and builds against the install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)