### PR TITLE
fix(MeshIO): index OBJ texture paths by chart, not MTL declaration order

### DIFF
--- a/include/educelab/core/io/MeshIO_OBJ.hpp
+++ b/include/educelab/core/io/MeshIO_OBJ.hpp
@@ -9,6 +9,7 @@
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "educelab/core/types/Color.hpp"
@@ -406,28 +407,46 @@ void read_obj_impl(
     if (!mtl) {
         return;  // MTL missing — no-op per spec
     }
-    std::vector<std::filesystem::path> ordered_paths;
+
+    // Collect (material name -> map_Kd path) in MTL declaration order.
+    std::vector<std::pair<std::string, std::filesystem::path>> mtl_materials;
     std::string mtl_line;
     std::vector<std::string_view> mt;
     while (std::getline(mtl, mtl_line)) {
-        // Tokenize
         split(mtl_line, mt);
-        // Skip comments
         if (mt.empty() || mt[0].front() == '#') {
             continue;
         }
-        if (mt[0] == "newmtl") {
-            ordered_paths.emplace_back();  // placeholder
+        if (mt[0] == "newmtl" && mt.size() >= 2) {
+            mtl_materials.emplace_back(
+                std::string(mt[1]), std::filesystem::path{});
         } else if (
-            mt[0] == "map_Kd" && !ordered_paths.empty() && mt.size() >= 2) {
-            ordered_paths.back() =
+            mt[0] == "map_Kd" && !mtl_materials.empty() && mt.size() >= 2) {
+            mtl_materials.back().second =
                 std::filesystem::path{std::string(mt[1])};
         }
     }
-    // Remove placeholder entries that had no map_Kd
-    for (const auto& p : ordered_paths) {
-        if (!p.empty()) {
-            texture_paths->push_back(p);
+
+    if (!material_index.empty()) {
+        // Chart indices are assigned in usemtl *usage* order, which can differ
+        // from the MTL's newmtl *declaration* order. Align texture_paths with
+        // chart indices by looking each material up by name, so
+        // texture_paths[chart] is that chart's image. Materials with no map_Kd
+        // (or absent from the MTL) keep an empty path so index alignment holds.
+        texture_paths->assign(material_index.size(), std::filesystem::path{});
+        for (const auto& [name, tex] : mtl_materials) {
+            if (auto it = material_index.find(name);
+                it != material_index.end()) {
+                (*texture_paths)[it->second] = tex;
+            }
+        }
+    } else {
+        // No usemtl directives: emit each map_Kd in declaration order (legacy
+        // single-/implicit-material behavior).
+        for (const auto& [name, tex] : mtl_materials) {
+            if (!tex.empty()) {
+                texture_paths->push_back(tex);
+            }
         }
     }
 }
@@ -858,9 +877,12 @@ void read_obj(
  * @brief Read an OBJ file into a mesh, UV map, and texture path list (Tier 3)
  *
  * In addition to Tier 2, parses the @c .mtl file referenced by the
- * @c mtllib directive and appends @c map_Kd paths (in material-declaration
- * order) to @p texture_paths. If no @c .mtl is referenced or no @c map_Kd
- * entries are present, @p texture_paths is left unchanged.
+ * @c mtllib directive and populates @p texture_paths indexed by UV **chart
+ * index** (i.e. @c usemtl usage order), resolving each material by name so
+ * @c texture_paths[chart] is that chart's @c map_Kd image. Any chart whose
+ * material has no @c map_Kd (or is absent from the @c .mtl) gets an empty
+ * path so indexing by chart stays valid. If no @c .mtl is referenced,
+ * @p texture_paths is left empty.
  *
  * @throws std::runtime_error if the OBJ file cannot be opened
  */

--- a/include/educelab/core/io/MeshIO_OBJ.hpp
+++ b/include/educelab/core/io/MeshIO_OBJ.hpp
@@ -316,9 +316,13 @@ void read_obj_impl(
                     ": invalid mtllib declaration");
             }
             // Resolve MTL path relative to the OBJ file. Capture everything
-            // starting with the first token in case the filename has spaces.
+            // from the first argument to end of line (trimmed) so the filename
+            // may contain spaces without a trailing CR / whitespace leaking in
+            // (e.g. from a CRLF line ending).
             const auto name_pos = std::string_view(line).find(tokens[1]);
-            mtllib_path = path.parent_path() / line.substr(name_pos);
+            mtllib_path =
+                path.parent_path() /
+                std::string(trim(std::string_view(line).substr(name_pos)));
         }
 
         // ---- Face ----

--- a/include/educelab/core/io/MeshIO_OBJ.hpp
+++ b/include/educelab/core/io/MeshIO_OBJ.hpp
@@ -405,7 +405,7 @@ void read_obj_impl(
     }
     std::ifstream mtl(mtllib_path);
     if (!mtl) {
-        return;  // MTL missing — no-op per spec
+        return;  // MTL missing / unreadable — leave texture_paths empty
     }
 
     // Collect (material name -> map_Kd path) in MTL declaration order.
@@ -422,8 +422,12 @@ void read_obj_impl(
                 std::string(mt[1]), std::filesystem::path{});
         } else if (
             mt[0] == "map_Kd" && !mtl_materials.empty() && mt.size() >= 2) {
-            mtl_materials.back().second =
-                std::filesystem::path{std::string(mt[1])};
+            // Capture everything from the first argument to end of line so
+            // texture filenames may contain spaces (mirrors the mtllib
+            // handling above). trim() drops any trailing whitespace / CR.
+            const auto arg_pos = std::string_view(mtl_line).find(mt[1]);
+            mtl_materials.back().second = std::filesystem::path{
+                std::string(trim(std::string_view(mtl_line).substr(arg_pos)))};
         }
     }
 
@@ -881,8 +885,15 @@ void read_obj(
  * index** (i.e. @c usemtl usage order), resolving each material by name so
  * @c texture_paths[chart] is that chart's @c map_Kd image. Any chart whose
  * material has no @c map_Kd (or is absent from the @c .mtl) gets an empty
- * path so indexing by chart stays valid. If no @c .mtl is referenced,
- * @p texture_paths is left empty.
+ * path so indexing by chart stays valid. If no @c .mtl is referenced, or the
+ * referenced @c .mtl cannot be opened, @p texture_paths is left empty.
+ *
+ * A @c map_Kd value captures the rest of the line (trimmed), so texture
+ * filenames may contain spaces. A @c newmtl with no material name is ignored,
+ * along with any @c map_Kd that would attach to it.
+ *
+ * If the OBJ contains no @c usemtl directives, each @c map_Kd is appended in
+ * @c .mtl declaration order instead (legacy single-/implicit-material meshes).
  *
  * @throws std::runtime_error if the OBJ file cannot be opened
  */

--- a/include/educelab/core/io/MeshIO_PLY.hpp
+++ b/include/educelab/core/io/MeshIO_PLY.hpp
@@ -235,9 +235,13 @@ inline auto parse_ply_header(std::istream& file) -> PLYHeader
                 // else ASCII (default)
             }
         } else if (tokens[0] == "comment") {
-            // Look for "comment TextureFile <path>"
+            // Look for "comment TextureFile <path>". Capture everything from
+            // the path's first token to end of line (trimmed) so filenames may
+            // contain spaces without a trailing CR / whitespace leaking in.
             if (tokens.size() >= 3 && tokens[1] == "TextureFile") {
-                h.texture_files.emplace_back(std::string(tokens[2]));
+                const auto name_pos = std::string_view(line).find(tokens[2]);
+                h.texture_files.emplace_back(
+                    std::string(trim(std::string_view(line).substr(name_pos))));
             }
         } else if (tokens[0] == "element") {
             if (tokens.size() < 3) {

--- a/tests/src/TestMeshIO.cpp
+++ b/tests/src/TestMeshIO.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <array>
 #include <filesystem>
 #include <fstream>
 #include <sstream>
@@ -593,6 +594,86 @@ TEST_F(OBJTest, ReadMultiChart_ChartIndicesOnlyWhenHasChart)
     EXPECT_EQ(dst_uv.size(), 6u);
 }
 
+// Writes three single-triangle charts to `path`, using materials in usemtl
+// usage order material_00, material_01, material_02. Each face gets its own
+// three vt entries so chart indices are assigned per-pool-index cleanly.
+static void write_three_chart_obj(const fs::path& path, const std::string& mtl)
+{
+    std::ofstream o(path);
+    o << "mtllib " << mtl << '\n';
+    o << "v 0 0 0\nv 1 0 0\nv 0 1 0\n";
+    o << "v 2 0 0\nv 3 0 0\nv 2 1 0\n";
+    o << "v 4 0 0\nv 5 0 0\nv 4 1 0\n";
+    o << "vt 0.0 0.0\nvt 0.1 0.0\nvt 0.0 0.1\n";
+    o << "vt 0.2 0.0\nvt 0.3 0.0\nvt 0.2 0.1\n";
+    o << "vt 0.4 0.0\nvt 0.5 0.0\nvt 0.4 0.1\n";
+    o << "usemtl material_00\nf 1/1 2/2 3/3\n";
+    o << "usemtl material_01\nf 4/4 5/5 6/6\n";
+    o << "usemtl material_02\nf 7/7 8/8 9/9\n";
+}
+
+// The .mtl declares materials in a different order than the .obj uses them.
+// Chart indices follow usemtl *usage* order; texture_paths must be aligned to
+// chart index by material *name*, not by .mtl declaration order.
+TEST_F(OBJTest, ReadMultiChart_TexturePathsIndexedByChartNotMtlOrder)
+{
+    {
+        std::ofstream mtl(dir / "reorder.mtl");
+        mtl << "newmtl material_00\nmap_Kd 00.jpg\n"   // decl 0
+            << "newmtl material_02\nmap_Kd 02.jpg\n"   // decl 1 (out of order)
+            << "newmtl material_01\nmap_Kd 01.jpg\n";  // decl 2
+    }
+    const auto path = obj("reorder");
+    write_three_chart_obj(path, "reorder.mtl");
+
+    Mesh3f dst_mesh;
+    ChartUVMap dst_uv;
+    std::vector<fs::path> tex;
+    read_obj(path, dst_mesh, dst_uv, tex);
+
+    ASSERT_EQ(dst_mesh.num_faces(), 3u);
+    ASSERT_EQ(tex.size(), 3u);
+    // Face fi uses material_0{fi}, whose map_Kd is 0{fi}.jpg. Whatever chart
+    // index that face resolved to, texture_paths[chart] must be its own image.
+    const std::array<fs::path, 3> expected{
+        fs::path("00.jpg"), fs::path("01.jpg"), fs::path("02.jpg")};
+    for (std::size_t fi = 0; fi < 3; ++fi) {
+        const auto chart = dst_uv.at(dst_uv.get(fi, 0)).chart;
+        EXPECT_EQ(tex[chart], expected[fi])
+            << "face " << fi << " (chart " << chart << ") got wrong texture";
+    }
+}
+
+// A used material with no map_Kd must keep an empty texture_paths slot (not be
+// compacted out), so later charts retain their correct images.
+TEST_F(OBJTest, ReadMultiChart_MaterialWithoutMapKd_PreservesEmptySlot)
+{
+    {
+        std::ofstream mtl(dir / "missing.mtl");
+        mtl << "newmtl material_00\nmap_Kd 00.jpg\n"
+            << "newmtl material_01\n"                  // no map_Kd
+            << "newmtl material_02\nmap_Kd 02.jpg\n";
+    }
+    const auto path = obj("missing");
+    write_three_chart_obj(path, "missing.mtl");
+
+    Mesh3f dst_mesh;
+    ChartUVMap dst_uv;
+    std::vector<fs::path> tex;
+    read_obj(path, dst_mesh, dst_uv, tex);
+
+    ASSERT_EQ(tex.size(), 3u);
+    // Charts follow usage order 00, 01, 02 → 0, 1, 2.
+    const auto chart0 = dst_uv.at(dst_uv.get(0, 0)).chart;
+    const auto chart1 = dst_uv.at(dst_uv.get(1, 0)).chart;
+    const auto chart2 = dst_uv.at(dst_uv.get(2, 0)).chart;
+    EXPECT_EQ(tex[chart0], fs::path("00.jpg"));
+    EXPECT_TRUE(tex[chart1].empty())
+        << "material with no map_Kd should keep an empty slot, got "
+        << tex[chart1];
+    EXPECT_EQ(tex[chart2], fs::path("02.jpg"));
+}
+
 TEST_F(OBJTest, NGonFace_Quad)
 {
     const auto src = make_quad();
@@ -643,7 +724,7 @@ TEST_F(OBJTest, WriteMissingDir_Throws)
         std::runtime_error);
 }
 
-TEST_F(OBJTest, MTLPresent_NoMapKd_EmptyTexturePaths)
+TEST_F(OBJTest, MTLPresent_NoMapKd_PreservesEmptyChartSlot)
 {
     // Write an OBJ that references a MTL but the MTL has no map_Kd
     const auto path     = obj("no_mapkd");
@@ -669,7 +750,10 @@ TEST_F(OBJTest, MTLPresent_NoMapKd_EmptyTexturePaths)
     std::vector<fs::path> dst_textures;
     read_obj(path, dst_mesh, dst_uv, dst_textures);
 
-    EXPECT_TRUE(dst_textures.empty());
+    // The used material (chart 0) has no map_Kd, but its slot is preserved as
+    // an empty path so texture_paths stays indexed by chart index.
+    ASSERT_EQ(dst_textures.size(), 1u);
+    EXPECT_TRUE(dst_textures[0].empty());
 }
 
 TEST_F(OBJTest, CombinedNormalsAndUVs_VTVNFormat)

--- a/tests/src/TestMeshIO.cpp
+++ b/tests/src/TestMeshIO.cpp
@@ -674,6 +674,103 @@ TEST_F(OBJTest, ReadMultiChart_MaterialWithoutMapKd_PreservesEmptySlot)
     EXPECT_EQ(tex[chart2], fs::path("02.jpg"));
 }
 
+// A material re-entered later in the OBJ (usemtl A ... B ... A) must resolve
+// to the same chart/texture on both uses; chart indexing is by name, so no new
+// chart is created on re-entry.
+TEST_F(OBJTest, ReadMultiChart_MaterialReEntry_ReusesSameChart)
+{
+    {
+        std::ofstream mtl(dir / "reentry.mtl");
+        mtl << "newmtl material_00\nmap_Kd a.jpg\n"
+            << "newmtl material_01\nmap_Kd b.jpg\n";
+    }
+    const auto path = obj("reentry");
+    {
+        std::ofstream o(path);
+        o << "mtllib reentry.mtl\n";
+        o << "v 0 0 0\nv 1 0 0\nv 0 1 0\n";
+        o << "v 2 0 0\nv 3 0 0\nv 2 1 0\n";
+        o << "v 4 0 0\nv 5 0 0\nv 4 1 0\n";
+        o << "vt 0.0 0.0\nvt 0.1 0.0\nvt 0.0 0.1\n";
+        o << "vt 0.2 0.0\nvt 0.3 0.0\nvt 0.2 0.1\n";
+        o << "vt 0.4 0.0\nvt 0.5 0.0\nvt 0.4 0.1\n";
+        o << "usemtl material_00\nf 1/1 2/2 3/3\n";   // chart for material_00
+        o << "usemtl material_01\nf 4/4 5/5 6/6\n";   // chart for material_01
+        o << "usemtl material_00\nf 7/7 8/8 9/9\n";   // re-entry of material_00
+    }
+
+    Mesh3f dst_mesh;
+    ChartUVMap dst_uv;
+    std::vector<fs::path> tex;
+    read_obj(path, dst_mesh, dst_uv, tex);
+
+    ASSERT_EQ(dst_mesh.num_faces(), 3u);
+    // Exactly two charts: material_00 and material_01. The re-entry does not
+    // create a third.
+    ASSERT_EQ(tex.size(), 2u);
+    const auto chart_f0 = dst_uv.at(dst_uv.get(0, 0)).chart;
+    const auto chart_f1 = dst_uv.at(dst_uv.get(1, 0)).chart;
+    const auto chart_f2 = dst_uv.at(dst_uv.get(2, 0)).chart;
+    EXPECT_EQ(chart_f0, chart_f2) << "re-entered material must reuse its chart";
+    EXPECT_NE(chart_f0, chart_f1);
+    EXPECT_EQ(tex[chart_f0], fs::path("a.jpg"));
+    EXPECT_EQ(tex[chart_f1], fs::path("b.jpg"));
+}
+
+// With no usemtl directives, texture_paths falls back to emitting each map_Kd
+// in .mtl declaration order (legacy single-/implicit-material behavior).
+TEST_F(OBJTest, ReadNoUsemtl_TexturePathsInDeclarationOrder)
+{
+    {
+        std::ofstream mtl(dir / "legacy.mtl");
+        mtl << "newmtl material_00\nmap_Kd first.jpg\n"
+            << "newmtl material_01\nmap_Kd second.jpg\n";
+    }
+    const auto path = obj("legacy");
+    {
+        std::ofstream o(path);
+        o << "mtllib legacy.mtl\n";
+        o << "v 0 0 0\nv 1 0 0\nv 0 1 0\n";
+        o << "vt 0 0\nvt 1 0\nvt 0 1\n";
+        o << "f 1/1 2/2 3/3\n";  // no usemtl
+    }
+
+    Mesh3f dst_mesh;
+    ChartUVMap dst_uv;
+    std::vector<fs::path> tex;
+    read_obj(path, dst_mesh, dst_uv, tex);
+
+    ASSERT_EQ(tex.size(), 2u);
+    EXPECT_EQ(tex[0], fs::path("first.jpg"));
+    EXPECT_EQ(tex[1], fs::path("second.jpg"));
+}
+
+// map_Kd captures the rest of the line, so texture filenames with spaces
+// survive the round-trip (previously truncated at the first token).
+TEST_F(OBJTest, ReadMapKd_FilenameWithSpaces)
+{
+    {
+        std::ofstream mtl(dir / "spaces.mtl");
+        mtl << "newmtl material_00\nmap_Kd my texture file.jpg\n";
+    }
+    const auto path = obj("spaces");
+    {
+        std::ofstream o(path);
+        o << "mtllib spaces.mtl\n";
+        o << "v 0 0 0\nv 1 0 0\nv 0 1 0\n";
+        o << "vt 0 0\nvt 1 0\nvt 0 1\n";
+        o << "usemtl material_00\nf 1/1 2/2 3/3\n";
+    }
+
+    Mesh3f dst_mesh;
+    ChartUVMap dst_uv;
+    std::vector<fs::path> tex;
+    read_obj(path, dst_mesh, dst_uv, tex);
+
+    ASSERT_EQ(tex.size(), 1u);
+    EXPECT_EQ(tex[0], fs::path("my texture file.jpg"));
+}
+
 TEST_F(OBJTest, NGonFace_Quad)
 {
     const auto src = make_quad();

--- a/tests/src/TestMeshIO.cpp
+++ b/tests/src/TestMeshIO.cpp
@@ -771,6 +771,33 @@ TEST_F(OBJTest, ReadMapKd_FilenameWithSpaces)
     EXPECT_EQ(tex[0], fs::path("my texture file.jpg"));
 }
 
+// CRLF line endings must not leak a trailing '\r' into the resolved mtllib
+// path; otherwise the MTL fails to open and texture_paths comes back empty.
+TEST_F(OBJTest, ReadMtllib_CRLFLineEndings)
+{
+    {
+        std::ofstream mtl(dir / "crlf.mtl");
+        mtl << "newmtl material_00\nmap_Kd tex.jpg\n";
+    }
+    const auto path = obj("crlf");
+    {
+        std::ofstream o(path, std::ios::binary);  // preserve CRLF
+        o << "mtllib crlf.mtl\r\n";
+        o << "v 0 0 0\r\nv 1 0 0\r\nv 0 1 0\r\n";
+        o << "vt 0 0\r\nvt 1 0\r\nvt 0 1\r\n";
+        o << "usemtl material_00\r\nf 1/1 2/2 3/3\r\n";
+    }
+
+    Mesh3f dst_mesh;
+    ChartUVMap dst_uv;
+    std::vector<fs::path> tex;
+    read_obj(path, dst_mesh, dst_uv, tex);
+
+    ASSERT_EQ(tex.size(), 1u);
+    EXPECT_EQ(tex[0], fs::path("tex.jpg"))
+        << "trailing CR leaked into the mtllib path (MTL failed to resolve)";
+}
+
 TEST_F(OBJTest, NGonFace_Quad)
 {
     const auto src = make_quad();
@@ -1477,6 +1504,71 @@ TEST_F(PLYTest, ReadCommentTextureFile_HandCraftedPLY)
     ASSERT_EQ(dst_textures.size(), 2u);
     EXPECT_EQ(dst_textures[0], fs::path("atlas0.png"));
     EXPECT_EQ(dst_textures[1], fs::path("atlas1.png"));
+}
+
+// A "comment TextureFile" path may contain spaces; the reader must capture the
+// whole line remainder, not just the first token.
+TEST_F(PLYTest, ReadCommentTextureFile_FilenameWithSpaces)
+{
+    const auto path = ply("spaced_texture");
+    {
+        std::ofstream f(path);
+        f << "ply\n"
+          << "format ascii 1.0\n"
+          << "comment TextureFile my atlas file.png\n"
+          << "element vertex 3\n"
+          << "property float x\n"
+          << "property float y\n"
+          << "property float z\n"
+          << "element face 1\n"
+          << "property list uchar int vertex_indices\n"
+          << "end_header\n"
+          << "0 0 0\n"
+          << "1 0 0\n"
+          << "0 1 0\n"
+          << "3 0 1 2\n";
+    }
+
+    Mesh3f dst_mesh;
+    UVMap2f dst_uv;
+    std::vector<fs::path> dst_textures;
+    read_ply(path, dst_mesh, dst_uv, dst_textures);
+
+    ASSERT_EQ(dst_textures.size(), 1u);
+    EXPECT_EQ(dst_textures[0], fs::path("my atlas file.png"));
+}
+
+// CRLF line endings must not leak a trailing '\r' into a captured texture path.
+TEST_F(PLYTest, ReadCommentTextureFile_CRLFLineEndings)
+{
+    const auto path = ply("crlf_texture");
+    {
+        // Write with explicit CRLF terminators (binary mode to preserve them).
+        std::ofstream f(path, std::ios::binary);
+        f << "ply\r\n"
+          << "format ascii 1.0\r\n"
+          << "comment TextureFile atlas.png\r\n"
+          << "element vertex 3\r\n"
+          << "property float x\r\n"
+          << "property float y\r\n"
+          << "property float z\r\n"
+          << "element face 1\r\n"
+          << "property list uchar int vertex_indices\r\n"
+          << "end_header\r\n"
+          << "0 0 0\r\n"
+          << "1 0 0\r\n"
+          << "0 1 0\r\n"
+          << "3 0 1 2\r\n";
+    }
+
+    Mesh3f dst_mesh;
+    UVMap2f dst_uv;
+    std::vector<fs::path> dst_textures;
+    read_ply(path, dst_mesh, dst_uv, dst_textures);
+
+    ASSERT_EQ(dst_textures.size(), 1u);
+    EXPECT_EQ(dst_textures[0], fs::path("atlas.png"))
+        << "trailing CR leaked into the texture path";
 }
 
 TEST_F(PLYTest, ReadMissingFile_Throws)


### PR DESCRIPTION
## Summary

Fix OBJ multi-chart texture misalignment by resolving material-to-texture mappings by **material name** instead of MTL declaration order. Extend robustness across OBJ and PLY readers to handle filenames with spaces and CRLF line endings.

## Changes

### OBJ reader core fix (MeshIO_OBJ.hpp)
- **Texture path indexing**: Align `texture_paths` by UV **chart index** (i.e. `usemtl` usage order), not MTL `newmtl` declaration order. Resolves each material by name so `texture_paths[chart]` is that chart's `map_Kd` image, fixing multi-chart meshes sampling textures from the wrong materials.
- **Empty-path preservation**: Materials with no `map_Kd` or absent from the MTL now keep an empty slot in `texture_paths` rather than being compacted out. This maintains alignment between chart indices and texture indices.
- **Legacy fallback**: When no `usemtl` directives are present, each `map_Kd` is appended in MTL declaration order (backwards-compatible with single-/implicit-material meshes).

### Path parsing robustness
- **OBJ mtllib**: The `mtllib` path now captures from the first argument to end-of-line (trimmed) to drop trailing CR from CRLF line endings.
- **OBJ map_Kd**: Now captures the trimmed rest of the line instead of just the first token, allowing texture filenames to contain spaces.
- **PLY comment TextureFile**: `parse_ply_header` now captures from the first token to end-of-line (trimmed), supporting spaces in filenames and preventing CRLF leakage.

### Documentation updates
- Updated doc comment on the Tier-3 `read_obj` overload to document new material-name-based indexing, empty-path preservation, and space/CRLF handling.

## Tests

- **ReadMultiChart_TexturePathsIndexedByChartNotMtlOrder**: Verifies that when MTL declares materials out-of-order, texture paths resolve by material name and align to chart indices.
- **ReadMultiChart_MaterialWithoutMapKd_PreservesEmptySlot**: Confirms that a material with no `map_Kd` keeps an empty texture path slot, preserving later charts' indices.
- **ReadMultiChart_MaterialReEntry_ReusesSameChart**: Ensures a material re-entered in the OBJ (e.g., `usemtl A ... B ... A`) reuses the same chart and texture path.
- **ReadNoUsemtl_TexturePathsInDeclarationOrder**: Validates legacy fallback behavior when no `usemtl` directives are present—textures emit in MTL declaration order.
- **ReadMapKd_FilenameWithSpaces**: Verifies OBJ reader preserves texture filenames containing spaces.
- **ReadMtllib_CRLFLineEndings**: Confirms CRLF line endings in OBJ do not leak a trailing CR into the mtllib path.
- **ReadCommentTextureFile_FilenameWithSpaces** (PLY): Verifies PLY reader preserves texture filenames with spaces in `comment TextureFile` lines.
- **ReadCommentTextureFile_CRLFLineEndings** (PLY): Confirms CRLF in PLY headers do not leak into texture paths.
- **MTLPresent_NoMapKd_PreservesEmptyChartSlot** (updated): Changed assertion from empty texture list to expecting one empty slot for the used chart.

## Downstream note

registration-toolkit consumes libcore via the Homebrew install. After this lands, that install must be rebuilt/reinstalled for `rt_reorder_texture` to pick up the fix. The RTK-side empty-path no-op change is already done and is forward-compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
